### PR TITLE
Fix CUDA Toolkit detection and ggml.dll load failures on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,10 @@ python -m venv .venv
 pip install -r requirements.txt
 
 # 3. Install llama-cpp-python with CUDA support
-# Download the appropriate wheel from:
+# setup.bat auto-detects your CUDA version and installs the matching wheel.
+# Manual install: download the wheel for your CUDA version from:
 # https://github.com/JamePeng/llama-cpp-python/releases
+#   CUDA 13.x -> cu130.basic   CUDA 12.8+ -> cu128.basic   CUDA 12.4 -> cu124.basic
 pip install llama_cpp_python-0.3.24+cu124.basic-cp312-cp312-win_amd64.whl
 
 # 4. Run
@@ -215,11 +217,12 @@ This is the standard sidecar format expected by most training tools (Kohya, Ever
 | Issue | Solution |
 |-------|----------|
 | **"Model not found"** | Place `.gguf` files in the parent directory (one level above `qwen3vl-captioner/`) |
-| **"CUDA not available"** | Install [CUDA Toolkit 12.x](https://developer.nvidia.com/cuda-downloads) and restart |
+| **"CUDA not available"** | Install the [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) (not just GPU drivers), then re-run `setup.bat` |
+| **"Failed to load ggml.dll"** | CUDA Toolkit missing or llama-cpp wheel doesn't match your CUDA version. Run `winget install Nvidia.CUDA`, then re-run `setup.bat` |
 | **Blank image preview** | Fixed in v1.4.2 — Qt image allocation limit raised to handle large files |
 | **Slow model loading** | Normal — first load takes 30-60s. Subsequent loads are faster |
 | **Out of VRAM** | Use Q6_K instead of Q8_0, or reduce `max_tokens` |
-| **"access violation"** | CUDA DLLs not found. Run `run.bat` (sets PATH automatically) |
+| **"access violation"** | CUDA DLLs not found. Run `run.bat` (sets PATH automatically) and ensure CUDA Toolkit is installed |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.2.0-blue" alt="Version"/>
   <img src="https://img.shields.io/badge/python-3.12-blue?logo=python" alt="Python"/>
-  <img src="https://img.shields.io/badge/GPU-CUDA%2012.x-green?logo=nvidia" alt="CUDA"/>
+  <img src="https://img.shields.io/badge/GPU-CUDA%2012.x--13.x-green?logo=nvidia" alt="CUDA"/>
   <img src="https://img.shields.io/badge/platform-Windows-lightgrey?logo=windows" alt="Platform"/>
 </p>
 
@@ -59,16 +59,47 @@ When enabled, this injects explicit instructions to describe **all** content (in
 
 ---
 
+## 📋 Prerequisites (Windows)
+
+Install these **before** running the app. `setup.bat` handles Python and Python packages automatically; the items below must be present on the system first.
+
+| Required | Notes |
+|----------|-------|
+| **Windows 10/11 (64-bit)** | Portable release is Windows-only |
+| **NVIDIA GPU (8 GB+ VRAM)** | GTX 1070 minimum; RTX 3060+ recommended |
+| **NVIDIA GPU driver (current)** | Install or update from [NVIDIA Drivers](https://www.nvidia.com/drivers) |
+| **NVIDIA CUDA Toolkit (12.4 – 13.x)** | **Required.** Drivers alone are not enough. Install via `winget install Nvidia.CUDA` or [CUDA Downloads](https://developer.nvidia.com/cuda-downloads) (~2–3 GB) |
+| **~10–15 GB free disk** | App, dependencies, and GGUF model files |
+
+**CUDA version notes**
+
+- Use a **current CUDA Toolkit** (12.4, 12.8, or 13.x). All are supported.
+- `setup.bat` detects your installed Toolkit and installs the matching `llama-cpp-python` build (`cu124`, `cu128`, or `cu130`).
+- The Toolkit version and the llama-cpp wheel **must match**. A common failure is installing the CUDA 13.x Toolkit while setup installs the CUDA 12.4 wheel — re-run `setup.bat` after installing CUDA so the correct wheel is selected.
+- GPU drivers can report a newer CUDA *capability* (e.g. 13.3) than the Toolkit you have installed. What matters is the **CUDA Toolkit on disk**, not the driver label alone.
+
+**Installed automatically by `setup.bat`:** Python 3.12, PyQt6, and the correct JamePeng `llama-cpp-python` CUDA wheel.
+
+---
+
 ## ⚡ Quick Start
 
-### 1. Run Setup
-Double-click `setup.bat` to automatically install Python and all necessary dependencies.
+### 1. Install CUDA Toolkit (if not already installed)
+```powershell
+winget install Nvidia.CUDA
+```
+Or download from [developer.nvidia.com/cuda-downloads](https://developer.nvidia.com/cuda-downloads).
 
-### 2. Get Models
+### 2. Run Setup
+Double-click `setup.bat` to install Python and all Python dependencies (including the CUDA-matched llama-cpp wheel).
+
+If you install CUDA **after** the first setup run, run `setup.bat` again so the correct wheel is installed.
+
+### 3. Get Models
 You can download models directly inside the app, or place your `.gguf` files in this same folder.
 **Recommended:** `Qwen3-VL-8B-Instruct-abliterated-v1.Q6_K.gguf`
 
-### 3. Launch
+### 4. Launch
 Double-click `run.bat` to start the captioner.
 
 ---
@@ -194,8 +225,8 @@ python app.py
 | **VRAM** | 8 GB | 12+ GB |
 | **RAM** | 16 GB | 32 GB |
 | **Storage** | ~10 GB (model + app) | ~15 GB (both quants) |
-| **CUDA** | 12.0 | 12.4 |
-| **Python** | 3.11 | 3.12 |
+| **CUDA Toolkit** | 12.4 | 13.x (latest) |
+| **Python** | 3.12 (via setup.bat) | 3.12 |
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -8,14 +8,20 @@ GGUF model in the parent directory, and launches the main window.
 import sys
 from pathlib import Path
 
-# CRITICAL: Initialize CUDA BEFORE importing PyQt6!
-# PyQt6 initialization interferes with CUDA context creation
+from engine.cuda_setup import cuda_toolkit_missing_message, setup_cuda_dll_path
+
+# CRITICAL: Load CUDA DLLs and initialize llama.cpp BEFORE importing PyQt6!
+# PyQt6 initialization interferes with CUDA context creation.
+setup_cuda_dll_path()
 try:
     import llama_cpp
+
     llama_cpp.llama_backend_init()
     print("[OK] CUDA backend initialized successfully (before PyQt6 import)")
 except Exception as e:
     print(f"[WARNING] Failed to initialize CUDA backend early: {e}")
+    if sys.platform == "win32" and "ggml.dll" in str(e):
+        print(cuda_toolkit_missing_message())
     print("[INFO] Will attempt regular initialization later")
 
 # Now safe to import PyQt6

--- a/engine/cuda_setup.py
+++ b/engine/cuda_setup.py
@@ -1,0 +1,117 @@
+"""
+Windows CUDA DLL path setup for llama-cpp-python.
+
+Must run before any llama_cpp import. GPU drivers alone do not ship the
+CUDA runtime DLLs (cudart, cublas, etc.) that ggml-cuda.dll needs.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _cuda_install_roots() -> list[Path]:
+    """Return CUDA toolkit install roots, newest version first."""
+    roots: list[Path] = []
+
+    cuda_env = os.environ.get("CUDA_PATH")
+    if cuda_env:
+        roots.append(Path(cuda_env))
+
+    toolkit_root = Path(r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA")
+    if toolkit_root.is_dir():
+        version_dirs = sorted(
+            (p for p in toolkit_root.iterdir() if p.is_dir() and p.name.startswith("v")),
+            key=lambda p: p.name,
+            reverse=True,
+        )
+        roots.extend(version_dirs)
+
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for root in roots:
+        resolved = root.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            unique.append(resolved)
+    return unique
+
+
+def _cuda_bin_dirs() -> list[Path]:
+    """Return existing CUDA bin directories to add to the DLL search path."""
+    dirs: list[Path] = []
+    for root in _cuda_install_roots():
+        for sub in ("bin", os.path.join("bin", "x64")):
+            path = root / sub
+            if path.is_dir():
+                dirs.append(path.resolve())
+    return dirs
+
+
+def setup_cuda_dll_path() -> Path | None:
+    """
+    Add CUDA and llama_cpp library directories to the DLL search path.
+
+    Returns the first CUDA bin directory found, or None if no toolkit is installed.
+    """
+    if sys.platform != "win32":
+        return None
+
+    import ctypes
+
+    for bin_dir in _cuda_bin_dirs():
+        os.add_dll_directory(str(bin_dir))
+        os.environ["PATH"] = str(bin_dir) + os.pathsep + os.environ.get("PATH", "")
+
+    try:
+        import importlib.util
+
+        spec = importlib.util.find_spec("llama_cpp")
+        if spec and spec.origin:
+            lib_dir = Path(spec.origin).resolve().parent / "lib"
+            if lib_dir.is_dir():
+                os.add_dll_directory(str(lib_dir))
+                os.environ["PATH"] = str(lib_dir) + os.pathsep + os.environ.get("PATH", "")
+    except Exception:
+        pass
+
+    cuda_bins = _cuda_bin_dirs()
+    if not cuda_bins:
+        return None
+
+    cuda_bin = cuda_bins[0]
+    for dll_path in sorted(cuda_bin.glob("cudart64_*.dll")):
+        try:
+            ctypes.CDLL(str(dll_path), winmode=ctypes.RTLD_GLOBAL)
+        except OSError:
+            pass
+
+    for dll_name in (
+        "cublas64_12.dll",
+        "cublasLt64_12.dll",
+        "cublas64_13.dll",
+        "cublasLt64_13.dll",
+    ):
+        dll_path = cuda_bin / dll_name
+        if dll_path.exists():
+            try:
+                ctypes.CDLL(str(dll_path), winmode=ctypes.RTLD_GLOBAL)
+            except OSError:
+                pass
+
+    return cuda_bin
+
+
+def cuda_toolkit_missing_message() -> str:
+    """Return a user-facing message when CUDA runtime DLLs are unavailable."""
+    return (
+        "CUDA runtime DLLs were not found. The NVIDIA GPU driver is installed, but "
+        "llama-cpp-python also needs the CUDA Toolkit (not just the driver).\n\n"
+        "Install CUDA Toolkit, then re-run setup.bat:\n"
+        "  winget install Nvidia.CUDA\n"
+        "  or https://developer.nvidia.com/cuda-downloads\n\n"
+        "Also ensure the llama-cpp-python wheel matches your CUDA version "
+        "(re-run setup.bat after installing CUDA)."
+    )

--- a/engine/inference.py
+++ b/engine/inference.py
@@ -17,70 +17,16 @@ from typing import Callable, Optional
 
 from PIL import Image
 
-
-def _setup_cuda_dll_path():
-    """
-    Manually preload CUDA DLLs using ctypes before llama.cpp initialization.
-
-    On Windows, llama-cpp-python with CUDA support requires CUDA runtime DLLs
-    (cudart64_12.dll, cublas64_12.dll, etc.) to be loaded. When launching
-    the GUI via double-click, the CUDA bin directory may not be in PATH, causing
-    "access violation reading 0x0000000000000000" errors during llama_backend_init().
-
-    We manually preload the DLLs using ctypes.CDLL() to ensure they're loaded
-    into the process before llama.cpp tries to use them.
-    """
-    if sys.platform != "win32":
-        return  # Only needed on Windows
-
-    # Common CUDA installation paths to check
-    cuda_paths = [
-        Path(r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\bin"),
-        Path(r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.1\bin"),
-        Path(r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0\bin"),
-    ]
-
-    # Also check CUDA_PATH environment variable
-    cuda_env = os.environ.get("CUDA_PATH")
-    if cuda_env:
-        cuda_paths.insert(0, Path(cuda_env) / "bin")
-
-    # Find first existing CUDA path
-    cuda_bin = None
-    for path in cuda_paths:
-        if path.exists():
-            cuda_bin = path
-            break
-
-    if not cuda_bin:
-        return  # No CUDA found, will fall back to CPU
-
-    # Critical CUDA DLLs that must be preloaded
-    critical_dlls = [
-        "cudart64_12.dll",
-        "cublas64_12.dll",
-        "cublasLt64_12.dll",
-    ]
-
-    # Preload DLLs using ctypes
-    import ctypes
-    for dll_name in critical_dlls:
-        dll_path = cuda_bin / dll_name
-        if dll_path.exists():
-            try:
-                ctypes.CDLL(str(dll_path))
-            except Exception:
-                pass  # Continue even if one DLL fails
-
+from engine.cuda_setup import setup_cuda_dll_path
 
 # Setup CUDA DLL path before importing llama_cpp
-_setup_cuda_dll_path()
+setup_cuda_dll_path()
 
 try:
     from llama_cpp import Llama
     from llama_cpp.llama_chat_format import Qwen25VLChatHandler
     LLAMA_CPP_AVAILABLE = True
-except ImportError:
+except Exception:
     LLAMA_CPP_AVAILABLE = False
 
 

--- a/run.bat
+++ b/run.bat
@@ -1,13 +1,20 @@
 @echo off
 cd /d "%~dp0"
 
-REM Add CUDA to PATH for DLL loading (prevents access violation errors)
-if exist "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\bin" (
-    set "PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\bin;%PATH%"
-) else if exist "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.1\bin" (
-    set "PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.1\bin;%PATH%"
-) else if exist "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0\bin" (
-    set "PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0\bin;%PATH%"
+REM Add CUDA to PATH for DLL loading (prevents ggml.dll / access violation errors)
+set "CUDA_ADDED="
+for /f "delims=" %%D in ('dir /b /ad /o-n "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v*" 2^>nul') do (
+    if not defined CUDA_ADDED (
+        set "PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\%%D\bin;%PATH%"
+        set "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\%%D"
+        set "CUDA_ADDED=1"
+    )
+)
+if not defined CUDA_ADDED (
+    echo [WARNING] CUDA Toolkit not found. Install from https://developer.nvidia.com/cuda-downloads
+    echo           or run: winget install Nvidia.CUDA
+    echo           Then re-run setup.bat to install the matching llama-cpp-python wheel.
+    echo.
 )
 
 if not exist ".venv\Scripts\python.exe" (

--- a/setup.bat
+++ b/setup.bat
@@ -6,6 +6,15 @@ echo   Qwen3-VL Captioner - Portable Setup
 echo   This will install everything needed to run the app.
 echo ============================================================
 echo.
+echo   PREREQUISITES (install these on your system first):
+echo     - Windows 10/11 (64-bit)
+echo     - NVIDIA GPU with current drivers
+echo     - NVIDIA CUDA Toolkit 12.4 - 13.x  (NOT just the GPU driver)
+echo       Install:  winget install Nvidia.CUDA
+echo.
+echo   Setup will install Python 3.12 and the llama-cpp wheel that
+echo   matches your CUDA Toolkit version. Re-run setup after installing CUDA.
+echo.
 
 REM --- Step 1: Get or verify uv ---
 echo [1/5] Checking for uv package manager...

--- a/setup.bat
+++ b/setup.bat
@@ -8,7 +8,7 @@ echo ============================================================
 echo.
 
 REM --- Step 1: Get or verify uv ---
-echo [1/4] Checking for uv package manager...
+echo [1/5] Checking for uv package manager...
 where uv >nul 2>&1
 if %ERRORLEVEL% NEQ 0 (
     echo      uv not found. Installing uv...
@@ -26,7 +26,7 @@ if %ERRORLEVEL% NEQ 0 (
 echo.
 
 REM --- Step 2: Install Python via uv ---
-echo [2/4] Installing Python 3.12 via uv...
+echo [2/5] Installing Python 3.12 via uv...
 uv python install 3.12
 if %ERRORLEVEL% NEQ 0 (
     echo [ERROR] Failed to install Python 3.12.
@@ -37,7 +37,7 @@ echo      Python 3.12 ready.
 echo.
 
 REM --- Step 3: Create virtual environment and install deps ---
-echo [3/4] Creating virtual environment and installing dependencies...
+echo [3/5] Creating virtual environment and installing dependencies...
 cd /d "%~dp0"
 
 uv venv --python 3.12 .venv
@@ -56,17 +56,41 @@ if %ERRORLEVEL% NEQ 0 (
 echo      Core dependencies installed.
 echo.
 
-REM --- Step 4: Install llama-cpp-python with Qwen3-VL support ---
-echo [4/4] Installing llama-cpp-python with Qwen3-VL support...
+REM --- Step 4: Detect CUDA Toolkit and select matching wheel ---
+echo [4/5] Detecting CUDA Toolkit...
+set "CUDA_VERSION="
+set "CUDA_WHEEL=cu124"
+for /f "usebackq tokens=1,2 delims=|" %%A in (`powershell -NoProfile -Command "$root='C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA'; if(-not(Test-Path $root)){Write-Output 'MISSING|cu124'; exit}; $dir=Get-ChildItem $root -Directory | Where-Object { $_.Name -match '^v' } | Sort-Object Name -Descending | Select-Object -First 1; if(-not $dir){Write-Output 'MISSING|cu124'; exit}; $ver=[version]($dir.Name.TrimStart('v')); $tag=if($ver.Major -ge 13){'cu130'}elseif($ver -ge [version]'12.8'){'cu128'}else{'cu124'}; Write-Output ($dir.Name+'|'+$tag)"`) do (
+    set "CUDA_VERSION=%%A"
+    set "CUDA_WHEEL=%%B"
+)
+
+if /I "!CUDA_VERSION!"=="MISSING" (
+    echo      [WARNING] CUDA Toolkit not found.
+    echo                GPU drivers alone are not enough - the CUDA Toolkit provides
+    echo                runtime DLLs required by llama-cpp-python.
+    echo.
+    echo                Install with:  winget install Nvidia.CUDA
+    echo                Or download:   https://developer.nvidia.com/cuda-downloads
+    echo.
+    echo                Continuing with default wheel ^(!CUDA_WHEEL!^) - you may need to
+    echo                re-run setup.bat after installing CUDA Toolkit.
+    echo.
+) else (
+    echo      Found CUDA Toolkit !CUDA_VERSION! - using !CUDA_WHEEL! wheel.
+)
+echo.
+
+REM --- Step 5: Install llama-cpp-python with Qwen3-VL support ---
+echo [5/5] Installing llama-cpp-python with Qwen3-VL support...
 echo.
 echo      Using JamePeng's fork with Qwen3-VL vision handler support.
 echo      Source: https://github.com/JamePeng/llama-cpp-python
 echo.
 
-REM Install JamePeng's llama-cpp-python v0.3.24 with CUDA 12.4 support
-REM This wheel includes Qwen3VLChatHandler and works with CUDA 12.1+ drivers
-echo      Installing llama-cpp-python v0.3.24 (CUDA 12.4)...
-uv pip install --python .venv\Scripts\python.exe "https://github.com/JamePeng/llama-cpp-python/releases/download/v0.3.24-cu124-Basic-win-20260208/llama_cpp_python-0.3.24%%2Bcu124.basic-cp312-cp312-win_amd64.whl"
+set "WHEEL_URL=https://github.com/JamePeng/llama-cpp-python/releases/download/v0.3.24-!CUDA_WHEEL!-Basic-win-20260208/llama_cpp_python-0.3.24%%2B!CUDA_WHEEL!.basic-cp312-cp312-win_amd64.whl"
+echo      Installing llama-cpp-python v0.3.24 ^(!CUDA_WHEEL!^)...
+uv pip install --python .venv\Scripts\python.exe "!WHEEL_URL!"
 
 if %ERRORLEVEL% EQU 0 (
     echo      llama-cpp-python with Qwen3-VL support installed successfully!
@@ -75,18 +99,15 @@ if %ERRORLEVEL% EQU 0 (
 
 echo.
 echo [ERROR] Failed to install llama-cpp-python.
-echo        This may indicate a network issue or missing CUDA drivers.
+echo        This may indicate a network issue or a wheel/CUDA version mismatch.
 echo.
 echo        Manual installation:
-echo        1. Download the wheel from:
+echo        1. Download the wheel matching your CUDA version from:
 echo           https://github.com/JamePeng/llama-cpp-python/releases
 echo        2. Install with: .venv\Scripts\pip.exe install [downloaded-file.whl]
 echo.
 pause
 exit /b 1
-
-:cuda_done
-echo      llama-cpp-python with CUDA support installed successfully!
 
 :install_done
 echo.


### PR DESCRIPTION
## Summary

Fixes `Failed to load ggml.dll` on Windows by detecting the installed CUDA Toolkit, installing the matching llama-cpp wheel, and loading CUDA DLLs before `llama_cpp` imports.

## What users need

1. **NVIDIA GPU** with current drivers
2. **CUDA Toolkit** (12.4, 12.8, or 13.x) — not just the driver (`winget install Nvidia.CUDA`)
3. Run **`setup.bat`**, then **`run.bat`**

`setup.bat` auto-selects the wheel: CUDA 13.x → `cu130`, 12.8+ → `cu128`, 12.4–12.7 → `cu124`. Re-run setup after installing CUDA.

## Changes

- `setup.bat` — CUDA detection + matching wheel install
- `run.bat` — auto-detect any CUDA Toolkit version on PATH
- `engine/cuda_setup.py` — shared CUDA DLL preloading
- `app.py` — CUDA setup before PyQt6 / `llama_cpp`
- `engine/inference.py` — use shared setup; catch load errors properly
- `README.md` — prerequisites and troubleshooting

## Test plan

- [ ] CUDA 13.x: setup installs `cu130`, app launches via `run.bat`
- [ ] CUDA 12.4: setup installs `cu124`, app launches via `run.bat`
- [ ] No Toolkit: setup warns; after installing CUDA and re-running setup, app works
