### PR TITLE
Fix failing CI: restore the pytest suite .gitignore swallowed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,10 +32,19 @@ ENGINEERING_NOTES.md
 FIX_SUMMARY.md
 TROUBLESHOOTING.md
 diagnose_cuda.py
-test_*.py
+# Ad-hoc scratch test scripts at the repo ROOT only (e.g. a throwaway
+# test_load.py while debugging). Root-anchored so it never swallows the
+# committed pytest suite under tests/ — an unanchored "test_*.py" here
+# previously hid tests/test_*.py, so those files silently failed to commit
+# and the CI "test" job had nothing to run.
+/test_*.py
 model_load_test*.log
 model_verbose*.log
 gui/VL_GGUF_Captioner*
+
+# Always keep the committed pytest suite's source, regardless of any test-*
+# patterns above. Scoped to *.py so __pycache__/*.pyc under tests/ stays ignored.
+!/tests/**/*.py
 
 # ─── OS files ─────────────────────────────────────────────
 .DS_Store

--- a/gui/config.py
+++ b/gui/config.py
@@ -4,6 +4,7 @@ Persistent application configuration for VL-CAPTIONER Studio Pro.
 Stores settings as JSON in ~/.vlcaptioner/config.json.
 """
 
+import copy
 import json
 from pathlib import Path
 from typing import Any, Dict
@@ -28,7 +29,10 @@ def _ensure_dir():
 
 def load_config() -> Dict[str, Any]:
     """Load config from disk, falling back to defaults for missing keys."""
-    cfg = dict(_DEFAULTS)
+    # Deep copy so mutable defaults (e.g. the custom_models list) are never
+    # shared with _DEFAULTS — otherwise callers like add_custom_model() would
+    # mutate the module-level defaults in place when no config file exists yet.
+    cfg = copy.deepcopy(_DEFAULTS)
     if _CONFIG_FILE.exists():
         try:
             with open(_CONFIG_FILE, "r", encoding="utf-8") as f:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared pytest setup for the core-logic suite.
+
+Two concerns are handled here:
+
+1. Import path. The tests import the app's own packages by their absolute
+   names (``engine.*`` / ``gui.*``). ``python -m pytest`` already puts the
+   repo root on ``sys.path``, but inserting it explicitly also lets the suite
+   run under a bare ``pytest tests/``.
+
+2. Headless Qt. ``gui.model_download_manager`` imports ``PyQt6.QtCore``; the
+   offscreen platform plugin lets it load on a CI runner with no display.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# Repo root = the directory that contains this tests/ folder.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")

--- a/tests/test_caption_cleanup.py
+++ b/tests/test_caption_cleanup.py
@@ -1,0 +1,79 @@
+"""Tests for caption post-processing (engine.base).
+
+``clean_caption`` strips chat-template noise that VLMs prepend; the GGUF and
+MLX engines both run every generated caption through it, so its behavior is
+load-bearing for output quality.
+"""
+
+import pytest
+
+from engine.base import apply_prefix_suffix, clean_caption
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("  A red car  ", "A red car"),
+        ("Caption: A red car", "A red car"),
+        ("caption: a red car", "a red car"),
+        ("Answer: 42", "42"),
+        ("Description: a dog", "a dog"),
+        ("Response: ok", "ok"),
+        ("Here is a photo of a cat", "a photo of a cat"),
+        ("Here's the scene", "the scene"),
+        ("Sure, a sunset", "a sunset"),
+        ("- a bullet caption", "a bullet caption"),
+        (":: weird colons", "weird colons"),
+        ("**bold lead", "bold lead"),
+    ],
+)
+def test_clean_caption_strips_known_noise(raw, expected):
+    assert clean_caption(raw) == expected
+
+
+def test_clean_caption_strips_only_first_prefix():
+    # The engine breaks after the first matching prefix — nested labels stay.
+    assert clean_caption("Answer: Caption: x") == "Caption: x"
+
+
+def test_clean_caption_empty_stays_empty():
+    assert clean_caption("") == ""
+    assert clean_caption("   ") == ""
+
+
+def test_clean_caption_prefix_only_falls_back_to_original():
+    # A caption that is *only* a prefix must not collapse to an empty string.
+    assert clean_caption("Caption:") == "Caption:"
+
+
+def test_clean_caption_is_idempotent():
+    once = clean_caption("Caption: A red car")
+    assert clean_caption(once) == once
+
+
+def test_clean_caption_preserves_internal_punctuation():
+    assert clean_caption("A cat: sitting") == "A cat: sitting"
+
+
+def test_apply_prefix_only():
+    assert apply_prefix_suffix("a cat", prefix="photo of") == "photo of a cat"
+
+
+def test_apply_suffix_only():
+    assert apply_prefix_suffix("a cat", suffix="indoors") == "a cat indoors"
+
+
+def test_apply_prefix_and_suffix():
+    assert apply_prefix_suffix("cat", prefix="a", suffix="b") == "a cat b"
+
+
+def test_apply_prefix_suffix_noop_when_empty():
+    assert apply_prefix_suffix("a cat") == "a cat"
+    assert apply_prefix_suffix("a cat", "", "") == "a cat"
+
+
+def test_apply_prefix_suffix_strips_affix_whitespace():
+    assert (
+        apply_prefix_suffix("cat", prefix="  photo  ", suffix="  now  ")
+        == "photo cat now"
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,87 @@
+"""Tests for persistent app config (gui.config).
+
+Covers the save/load round-trip, default-fill for missing keys, corrupt-file
+recovery, custom-model dedup (most-recent-last), and the auto-save toggle.
+
+Each test is isolated to a temp config file via an autouse fixture, so the
+developer's real ~/.vlcaptioner/config.json is never read or written.
+"""
+
+import pytest
+
+from gui import config as cfg
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config(tmp_path, monkeypatch):
+    """Redirect the module's config dir/file to a per-test temp location."""
+    cfg_dir = tmp_path / ".vlcaptioner"
+    cfg_file = cfg_dir / "config.json"
+    monkeypatch.setattr(cfg, "_CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(cfg, "_CONFIG_FILE", cfg_file)
+    return cfg_file
+
+
+def test_load_defaults_when_no_file():
+    loaded = cfg.load_config()
+    assert loaded["theme"] == "dark"
+    assert loaded["hf_token"] == ""
+    assert loaded["custom_models"] == []
+    assert loaded["auto_save_captions"] is False
+
+
+def test_save_load_round_trip(_isolated_config):
+    data = {
+        "theme": "light",
+        "hf_token": "hf_secret",
+        "custom_models": ["/models/a.gguf"],
+        "auto_save_captions": True,
+    }
+    cfg.save_config(data)
+    assert _isolated_config.exists()
+    loaded = cfg.load_config()
+    for key, value in data.items():
+        assert loaded[key] == value
+
+
+def test_partial_config_merges_defaults():
+    cfg.save_config({"theme": "light"})
+    loaded = cfg.load_config()
+    assert loaded["theme"] == "light"
+    # Keys absent from disk fall back to defaults.
+    assert loaded["hf_token"] == ""
+    assert loaded["auto_save_captions"] is False
+
+
+def test_corrupt_file_falls_back_to_defaults(_isolated_config):
+    _isolated_config.parent.mkdir(parents=True, exist_ok=True)
+    _isolated_config.write_text("{not valid json", encoding="utf-8")
+    loaded = cfg.load_config()
+    assert loaded["theme"] == "dark"
+
+
+def test_add_custom_model_dedups_most_recent_last():
+    cfg.add_custom_model("/m/a.gguf")
+    cfg.add_custom_model("/m/b.gguf")
+    cfg.add_custom_model("/m/a.gguf")  # re-adding moves it to the end
+    assert cfg.get_custom_models() == ["/m/b.gguf", "/m/a.gguf"]
+
+
+def test_get_custom_models_returns_list():
+    assert cfg.get_custom_models() == []
+    cfg.add_custom_model("/m/a.gguf")
+    assert cfg.get_custom_models() == ["/m/a.gguf"]
+
+
+def test_auto_save_toggle_round_trips():
+    assert cfg.get_auto_save_captions() is False
+    cfg.set_auto_save_captions(True)
+    assert cfg.get_auto_save_captions() is True
+    cfg.set_auto_save_captions(False)
+    assert cfg.get_auto_save_captions() is False
+
+
+def test_theme_and_token_convenience():
+    cfg.save_config({"theme": "light", "hf_token": "hf_abc"})
+    assert cfg.get_theme() == "light"
+    assert cfg.get_hf_token() == "hf_abc"

--- a/tests/test_cuda_setup.py
+++ b/tests/test_cuda_setup.py
@@ -1,0 +1,122 @@
+"""Tests for CUDA toolkit detection and wheel-tag mapping (engine.cuda_setup).
+
+Regression guard for the ggml.dll / wheel-mismatch crashes in issues #8/#10:
+an installed CUDA Toolkit version must map to the matching llama-cpp-python
+wheel tag, and toolkit version comparison must be numeric (so 12.10 ranks
+above 12.8, not below it as a string compare would).
+"""
+
+import pytest
+
+from engine import cuda_setup
+from engine.cuda_setup import (
+    DEFAULT_WHEEL_TAG,
+    cuda_toolkit_missing_message,
+    detect_cuda_toolkit,
+    installed_wheel_cuda_tag,
+    parse_cuda_version,
+    recommended_wheel_tag,
+    wheel_mismatch_message,
+)
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("v12.4", (12, 4)),
+        ("12.4", (12, 4)),
+        ("v13.0", (13, 0)),
+        ("CUDA Version 12.10", (12, 10)),
+        ("v13.1", (13, 1)),
+    ],
+)
+def test_parse_cuda_version_ok(text, expected):
+    assert parse_cuda_version(text) == expected
+
+
+@pytest.mark.parametrize("text", ["", "v13", "nonsense", "cuda"])
+def test_parse_cuda_version_rejects_garbage(text):
+    assert parse_cuda_version(text) is None
+
+
+@pytest.mark.parametrize(
+    "version, tag",
+    [
+        ((13, 1), "cu131"),
+        ((13, 5), "cu131"),
+        ((14, 0), "cu131"),
+        ((13, 0), "cu130"),
+        ((12, 8), "cu128"),
+        ((12, 9), "cu128"),
+        ((12, 6), "cu126"),
+        ((12, 7), "cu126"),
+        ((12, 4), "cu124"),
+        ((12, 5), "cu124"),
+    ],
+)
+def test_recommended_wheel_tag(version, tag):
+    assert recommended_wheel_tag(version) == tag
+
+
+def test_recommended_wheel_tag_none_is_default():
+    assert recommended_wheel_tag(None) == DEFAULT_WHEEL_TAG
+    assert DEFAULT_WHEEL_TAG == "cu124"
+
+
+def test_recommended_wheel_tag_below_floor_is_default():
+    # Toolkits older than any shipped wheel fall back to the default tag.
+    assert recommended_wheel_tag((12, 3)) == DEFAULT_WHEEL_TAG
+    assert recommended_wheel_tag((11, 8)) == DEFAULT_WHEEL_TAG
+
+
+def test_wheel_tag_ordering_is_numeric_not_lexical():
+    # 12.10 must rank above 12.8 (a string compare would pick the wrong tag).
+    assert recommended_wheel_tag((12, 10)) == "cu128"
+    assert recommended_wheel_tag((12, 10)) != "cu131"
+
+
+def test_cu131_tag_is_reachable():
+    tags = [tag for _, tag in cuda_setup._WHEEL_TAGS]
+    assert "cu131" in tags
+    assert recommended_wheel_tag((13, 1)) == "cu131"
+
+
+def test_installed_wheel_cuda_tag_shape():
+    # None when no CUDA llama-cpp-python wheel is installed; a "cuNNN" string
+    # when one is present. Either way it must never raise.
+    tag = installed_wheel_cuda_tag()
+    assert tag is None or tag.startswith("cu")
+
+
+def test_toolkit_missing_message_is_actionable():
+    msg = cuda_toolkit_missing_message()
+    assert "CUDA Toolkit" in msg
+    assert "setup.bat" in msg
+
+
+def test_wheel_mismatch_message_names_both_tags():
+    msg = wheel_mismatch_message("cu130", "cu124")
+    assert "cu130" in msg
+    assert "cu124" in msg
+    assert "setup.bat" in msg
+
+
+def test_detect_cuda_toolkit_picks_newest_numerically(tmp_path, monkeypatch):
+    # Three installed toolkits; detection picks v13.0 and ranks v12.10 above
+    # v12.4 (numeric, not lexical).
+    monkeypatch.delenv("CUDA_PATH", raising=False)
+    for name in ("v12.4", "v12.10", "v13.0"):
+        (tmp_path / name).mkdir()
+    monkeypatch.setattr(cuda_setup, "_TOOLKIT_ROOT", tmp_path)
+
+    detected = detect_cuda_toolkit()
+    assert detected is not None
+    version, root = detected
+    assert version == (13, 0)
+    assert root.name == "v13.0"
+
+
+def test_detect_cuda_toolkit_none_when_no_install(tmp_path, monkeypatch):
+    monkeypatch.delenv("CUDA_PATH", raising=False)
+    monkeypatch.setattr(cuda_setup, "_TOOLKIT_ROOT", tmp_path / "does-not-exist")
+    assert detect_cuda_toolkit() is None

--- a/tests/test_mlx_engine.py
+++ b/tests/test_mlx_engine.py
@@ -1,0 +1,58 @@
+"""Tests for MLX model-folder detection (engine.mlx_engine).
+
+An MLX model is a directory holding ``config.json`` plus at least one
+``*.safetensors`` shard (the vision tower is embedded — no mmproj file).
+"""
+
+import sys
+
+from engine.mlx_engine import MLX_SUPPORTED, is_mlx_model_dir
+
+
+def _make_mlx_folder(path):
+    path.mkdir()
+    (path / "config.json").write_text("{}", encoding="utf-8")
+    (path / "model.safetensors").write_bytes(b"\x00")
+
+
+def test_is_mlx_model_dir_true_for_complete_folder(tmp_path):
+    folder = tmp_path / "model"
+    _make_mlx_folder(folder)
+    assert is_mlx_model_dir(folder) is True
+
+
+def test_is_mlx_model_dir_accepts_string_path(tmp_path):
+    folder = tmp_path / "model"
+    _make_mlx_folder(folder)
+    assert is_mlx_model_dir(str(folder)) is True
+
+
+def test_is_mlx_model_dir_false_when_missing(tmp_path):
+    assert is_mlx_model_dir(tmp_path / "nope") is False
+
+
+def test_is_mlx_model_dir_false_for_file(tmp_path):
+    f = tmp_path / "model.gguf"
+    f.write_bytes(b"\x00")
+    assert is_mlx_model_dir(f) is False
+
+
+def test_is_mlx_model_dir_false_without_config(tmp_path):
+    folder = tmp_path / "model"
+    folder.mkdir()
+    (folder / "model.safetensors").write_bytes(b"\x00")
+    assert is_mlx_model_dir(folder) is False
+
+
+def test_is_mlx_model_dir_false_without_safetensors(tmp_path):
+    folder = tmp_path / "model"
+    folder.mkdir()
+    (folder / "config.json").write_text("{}", encoding="utf-8")
+    assert is_mlx_model_dir(folder) is False
+
+
+def test_mlx_supported_matches_platform():
+    import platform
+
+    expected = sys.platform == "darwin" and platform.machine() == "arm64"
+    assert MLX_SUPPORTED == expected

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,135 @@
+"""Tests for the model registry, backend routing, and dropdown grouping
+(gui.model_download_manager).
+
+Covers registry integrity (every GGUF model paired with an mmproj vision
+encoder), backend routing (``gguf`` vs ``mlx``), the recommended default, and
+the parallel group/label structure that drives the dropdown headers.
+"""
+
+from gui.model_download_manager import (
+    MLX_MODEL_REGISTRY,
+    MODEL_REGISTRY,
+    get_all_model_display_names,
+    get_model_group_labels,
+    get_model_groups,
+    get_model_info,
+    mlx_backend_supported,
+    mlx_model_exists,
+    model_file_exists,
+)
+
+
+def test_gguf_registry_non_empty():
+    assert len(MODEL_REGISTRY) >= 1
+
+
+def test_every_gguf_entry_has_required_fields():
+    for entry in MODEL_REGISTRY.values():
+        assert entry["repo_id"]
+        assert entry["filename"].endswith(".gguf")
+        # Every GGUF model must be paired with an mmproj vision encoder,
+        # otherwise the model loads but produces blank/garbage captions.
+        assert entry["mmproj_filename"].endswith(".gguf")
+        assert isinstance(entry["size_gb"], (int, float))
+        assert isinstance(entry["recommended"], bool)
+
+
+def test_only_v2_family_is_recommended():
+    recommended = [n for n, e in MODEL_REGISTRY.items() if e["recommended"]]
+    assert recommended, "expected at least one recommended default model"
+    for name in recommended:
+        assert "v2" in name
+
+
+def test_v2_filename_and_mmproj_templating():
+    entry = MODEL_REGISTRY["Qwen3-VL 8B ABL v2 — Q4_K_M (4.68 GB)"]
+    assert entry["filename"] == "Qwen3-VL-8B-Instruct-abliterated-v2.Q4_K_M.gguf"
+    assert entry["mmproj_filename"] == (
+        "Qwen3-VL-8B-Instruct-abliterated-v2.mmproj-f16.gguf"
+    )
+    assert entry["recommended"] is True
+
+
+def test_huihui_uses_dash_quant_template():
+    # The huihui family uses "{stem}-{quant}.gguf", not "{stem}.{quant}.gguf".
+    entry = MODEL_REGISTRY["Huihui Qwen3-VL 8B ABL — Q4_K_M (4.68 GB)"]
+    assert entry["filename"] == "Huihui-Qwen3-VL-8B-Instruct-abliterated-Q4_K_M.gguf"
+    assert entry["mmproj_filename"] == "mmproj-F16.gguf"
+
+
+def test_mlx_registry_entries_are_folder_based():
+    assert len(MLX_MODEL_REGISTRY) >= 1
+    for entry in MLX_MODEL_REGISTRY.values():
+        assert entry["backend"] == "mlx"
+        assert entry["repo_id"]
+        assert entry["folder"]
+        # MLX models embed the vision tower — no separate mmproj file.
+        assert "mmproj_filename" not in entry
+
+
+def test_get_model_info_routes_gguf():
+    info = get_model_info("Qwen3-VL 8B ABL v2 — Q4_K_M (4.68 GB)")
+    assert info is not None
+    assert info["backend"] == "gguf"
+    assert info["mmproj_filename"].endswith(".gguf")
+
+
+def test_get_model_info_routes_mlx():
+    info = get_model_info("Qwen3-VL 8B ABL v2 MLX — 4bit (5.4 GB)")
+    assert info is not None
+    assert info["backend"] == "mlx"
+    assert info["folder"]
+
+
+def test_get_model_info_unknown_returns_none():
+    assert get_model_info("Totally Not A Model") is None
+
+
+def test_no_duplicate_display_names():
+    combined = list(MODEL_REGISTRY) + list(MLX_MODEL_REGISTRY)
+    assert len(combined) == len(set(combined))
+
+
+def test_groups_and_labels_are_parallel():
+    groups = get_model_groups()
+    labels = get_model_group_labels()
+    assert len(groups) == len(labels)
+    assert all(isinstance(label, str) and label for label in labels)
+    assert all(len(group) >= 1 for group in groups)
+
+
+def test_groups_flatten_to_display_names():
+    flat = [name for group in get_model_groups() for name in group]
+    assert flat == get_all_model_display_names()
+
+
+def test_display_names_are_known_registry_entries():
+    known = set(MODEL_REGISTRY) | set(MLX_MODEL_REGISTRY)
+    for name in get_all_model_display_names():
+        assert name in known
+
+
+def test_mlx_backend_supported_matches_platform():
+    import platform
+    import sys
+
+    assert mlx_backend_supported() == (
+        sys.platform == "darwin" and platform.machine() == "arm64"
+    )
+
+
+def test_model_file_exists(tmp_path):
+    assert model_file_exists(tmp_path, "x.gguf") is False
+    (tmp_path / "x.gguf").write_bytes(b"\x00")
+    assert model_file_exists(tmp_path, "x.gguf") is True
+
+
+def test_mlx_model_exists(tmp_path):
+    assert mlx_model_exists(tmp_path, "m") is False
+    folder = tmp_path / "m"
+    folder.mkdir()
+    (folder / "config.json").write_text("{}", encoding="utf-8")
+    # config.json alone is not enough — needs safetensors too.
+    assert mlx_model_exists(tmp_path, "m") is False
+    (folder / "model.safetensors").write_bytes(b"\x00")
+    assert mlx_model_exists(tmp_path, "m") is True


### PR DESCRIPTION
## What was broken

CI on `main` was failing the **Lint & Test / lint** and **Lint & Test / test** checks (the 2 red checks in the screenshot).

Root cause: commit `50acaa1` ("Add pytest suite for core logic + wire into CI") renamed the workflow to *Lint & Test* and added a `test` job, but **the actual `tests/` files were never committed.** The unanchored `test_*.py` pattern in `.gitignore` matched `tests/test_*.py`, so `git add` silently skipped them. Only the workflow + `requirements-dev.txt` changes landed, leaving CI pointed at a directory that didn't exist:

- **lint job** → `pyflakes ... tests/*.py` → `tests/*.py: No such file or directory` → exit 1 ❌
- **test job** → `pytest tests/` → no tests directory → exit 4 ❌

## Fixes

- **`.gitignore`** — root-anchor the scratch pattern (`/test_*.py`) so it only ignores throwaway scripts at the repo root, plus a scoped `!/tests/**/*.py` guard so the committed suite can never be hidden again (while `__pycache__/*.pyc` under `tests/` stays ignored).
- **Restore the test suite** — 81 tests covering the areas the original commit documented:
  - CUDA toolkit → wheel-tag mapping (incl. numeric ordering so `12.10` ranks above `12.8`, and `cu131`) — regression guard for the `ggml.dll` / wheel-mismatch crashes in #8/#10
  - caption cleanup (`clean_caption` / `apply_prefix_suffix`)
  - MLX model-folder detection
  - model registry integrity & backend routing (gguf vs mlx, mmproj pairing, recommended default, dropdown groups/labels)
  - config persistence round-trip, custom-model dedup, auto-save toggle
- **`gui/config.py`** — fix a real bug the suite surfaced: `load_config()` did a shallow `dict(_DEFAULTS)` copy, so `add_custom_model()` mutated the shared default `custom_models` list **in place**, polluting the module-level defaults for the rest of the process. Now uses `copy.deepcopy()`.

## Verification

Ran the exact CI steps locally (Python 3.11, `QT_QPA_PLATFORM=offscreen`):

```
compileall  → exit 0
pyflakes    → exit 0
pytest      → 81 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMYNNVhD1EvDD8oQ3bvhpT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMYNNVhD1EvDD8oQ3bvhpT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration issue where custom model lists were unintentionally shared across sessions.

* **Tests**
  * Added comprehensive test coverage for configuration management, CUDA detection, model registry, and caption processing to improve overall reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->