### PR TITLE
Fix 6 issues from a deep review (downloads, MLX, batch threading, UI)

### DIFF
--- a/engine/mlx_engine.py
+++ b/engine/mlx_engine.py
@@ -53,7 +53,10 @@ def _load_make_sampler():
     try:
         from mlx_lm.sample_utils import make_sampler
         return make_sampler
-    except Exception:
+    except ImportError:
+        # mlx_lm missing or too old to expose make_sampler — use legacy kwargs.
+        # (By the time this runs mlx is already imported, so a non-import error
+        # here would be a genuine problem and should not be masked.)
         return None
 
 

--- a/engine/mlx_engine.py
+++ b/engine/mlx_engine.py
@@ -44,6 +44,43 @@ def is_mlx_model_dir(path: Path) -> bool:
     )
 
 
+def _load_make_sampler():
+    """Return mlx's make_sampler factory, or None on older/missing mlx.
+
+    Newer mlx-lm exposes sampling parameters through a sampler callable; if it
+    isn't importable we fall back to the legacy temperature/top_p kwargs.
+    """
+    try:
+        from mlx_lm.sample_utils import make_sampler
+        return make_sampler
+    except Exception:
+        return None
+
+
+def _stream_with_sampling(
+    stream_generate, args, kwargs, temperature, top_p, make_sampler="auto"
+):
+    """Invoke mlx-vlm's stream_generate across a breaking sampling-API change.
+
+    mlx-vlm/mlx-lm dropped the ``temperature``/``top_p`` keyword arguments on
+    ``stream_generate`` in favour of a ``sampler`` callable, and the project
+    pins only ``mlx-vlm>=0.1.0`` (no upper bound) — so a fresh setup.sh install
+    pulls the newer API where the old kwargs raise ``TypeError`` on every
+    caption. Prefer the sampler path; if this build doesn't accept ``sampler``
+    (older 0.1.x), fall back to the legacy kwargs so captioning works on either
+    version.
+    """
+    if make_sampler == "auto":
+        make_sampler = _load_make_sampler()
+    if make_sampler is not None:
+        try:
+            sampler = make_sampler(temp=temperature, top_p=top_p)
+            return stream_generate(*args, sampler=sampler, **kwargs)
+        except TypeError:
+            pass  # this build doesn't accept a sampler — use legacy kwargs
+    return stream_generate(*args, temperature=temperature, top_p=top_p, **kwargs)
+
+
 class MlxVlmEngine:
     """
     Inference engine for MLX-format Qwen3-VL models via mlx-vlm.
@@ -148,15 +185,16 @@ class MlxVlmEngine:
         start_time = time.perf_counter()
         caption_parts = []
 
-        for chunk in stream_generate(
-            self.model,
-            self.processor,
-            formatted_prompt,
-            image=[str(image_path)],
-            max_tokens=max_tokens,
-            temperature=temperature if temperature > 0 else 0.0,
-            top_p=top_p if temperature > 0 else 1.0,
-        ):
+        temp = temperature if temperature > 0 else 0.0
+        nucleus = top_p if temperature > 0 else 1.0
+        token_stream = _stream_with_sampling(
+            stream_generate,
+            (self.model, self.processor, formatted_prompt),
+            {"image": [str(image_path)], "max_tokens": max_tokens},
+            temp,
+            nucleus,
+        )
+        for chunk in token_stream:
             if cancel_check and cancel_check():
                 break
             text = getattr(chunk, "text", None)

--- a/engine/mlx_engine.py
+++ b/engine/mlx_engine.py
@@ -73,11 +73,19 @@ def _stream_with_sampling(
     if make_sampler == "auto":
         make_sampler = _load_make_sampler()
     if make_sampler is not None:
+        # Build the sampler OUTSIDE the try: a failure here is a real
+        # make_sampler problem and must not be mistaken for "this build has no
+        # sampler kwarg" (which would wrongly retry the legacy kwargs and crash
+        # on a newer mlx-vlm that removed them).
+        sampler = make_sampler(temp=temperature, top_p=top_p)
         try:
-            sampler = make_sampler(temp=temperature, top_p=top_p)
             return stream_generate(*args, sampler=sampler, **kwargs)
-        except TypeError:
-            pass  # this build doesn't accept a sampler — use legacy kwargs
+        except TypeError as exc:
+            # Only fall back when stream_generate specifically rejects the
+            # `sampler` keyword (older 0.1.x). Any other TypeError is a genuine
+            # error and must propagate.
+            if "sampler" not in str(exc):
+                raise
     return stream_generate(*args, temperature=temperature, top_p=top_p, **kwargs)
 
 

--- a/engine/model_downloader.py
+++ b/engine/model_downloader.py
@@ -106,7 +106,6 @@ def download_mmproj(
                 repo_id=repo_id,
                 filename=filename,
                 local_dir=str(target_dir),
-                local_dir_use_symlinks=False,
             )
             
             result_path = Path(downloaded_path)
@@ -160,7 +159,6 @@ def download_named_mmproj(
         repo_id=repo_id,
         filename=filename,
         local_dir=str(target_dir),
-        local_dir_use_symlinks=False,
     )
     result = Path(downloaded_path)
 

--- a/gui/app_settings_dialog.py
+++ b/gui/app_settings_dialog.py
@@ -33,6 +33,8 @@ class AppSettingsDialog(QDialog):
         )
 
         self._cfg = load_config()
+        # Remember the theme we opened with so Cancel can undo a live preview.
+        self._orig_theme = self._cfg.get("theme", "dark")
         self._build_ui()
 
     # ------------------------------------------------------------------ #
@@ -290,6 +292,14 @@ class AppSettingsDialog(QDialog):
         mode = "dark" if self._dark_mode_cb.isChecked() else "light"
         self._cfg["theme"] = mode
         self.theme_changed.emit(mode)
+
+    def reject(self):
+        """Cancel: undo any live theme preview so the running app matches the
+        still-unchanged saved config."""
+        current = "dark" if self._dark_mode_cb.isChecked() else "light"
+        if current != self._orig_theme:
+            self.theme_changed.emit(self._orig_theme)
+        super().reject()
 
     def _save_and_close(self):
         self._cfg["theme"] = "dark" if self._dark_mode_cb.isChecked() else "light"

--- a/gui/caption_panel.py
+++ b/gui/caption_panel.py
@@ -197,8 +197,10 @@ class CaptionPanel(QFrame):
         if text:
             clipboard = QApplication.clipboard()
             clipboard.setText(text)
-            # Swap icon to checkmark for 2 seconds
-            original_text = self.copy_btn.text()
+            # Swap icon to checkmark for 2 seconds. Restore to the fixed
+            # clipboard glyph (not the button's current text) so a second click
+            # within the 2s window doesn't capture the checkmark and leave the
+            # button stuck showing it.
             self.copy_btn.setText("\u2714")  # heavy checkmark
             self.copy_btn.setStyleSheet(
                 f"color: {COLORS['success']}; background: transparent; "
@@ -207,7 +209,7 @@ class CaptionPanel(QFrame):
             self.show_feedback("Copied!")
 
             def _restore():
-                self.copy_btn.setText(original_text)
+                self.copy_btn.setText("\U0001F4CB")  # clipboard
                 self.copy_btn.setStyleSheet("")
                 self.copy_btn.setProperty("class", "icon-button")
                 self.copy_btn.style().unpolish(self.copy_btn)

--- a/gui/image_viewer.py
+++ b/gui/image_viewer.py
@@ -276,7 +276,9 @@ class ImageViewer(QFrame):
         # Calculate scale to fit
         scale_w = (view_size.width() - 20) / img_w
         scale_h = (view_size.height() - 20) / img_h
-        self._zoom = min(scale_w, scale_h, 1.0)  # Don't upscale beyond 100%
+        # Clamp to a sane floor (as _set_zoom does) so a momentarily-degenerate
+        # view size can't produce a zero/negative zoom and a blank image.
+        self._zoom = max(0.1, min(scale_w, scale_h, 1.0))  # Don't upscale beyond 100%
 
         self._apply_zoom()
 

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1314,6 +1314,14 @@ class MainWindow(QMainWindow):
         self._image_viewer.set_processing(True)
         self._set_connection_status("generating", "Generating...")
 
+        # Keep references to finishing generation threads (mirrors the download
+        # path) so a still-shutting-down QThread from the previous batch item
+        # isn't garbage-collected while its C++ side is alive ("QThread
+        # destroyed while still running").
+        self._finished_threads = [t for t in self._finished_threads if t.isRunning()]
+        if self._generation_thread is not None:
+            self._finished_threads.append(self._generation_thread)
+
         # Start generation in background thread — store as instance attrs
         self._generation_thread = QThread()
         self._caption_worker = CaptionWorker(
@@ -1539,7 +1547,18 @@ class MainWindow(QMainWindow):
         self._queue_label.setText(f"Queue: {len(self._batch_queue)} remaining")
 
         # Generate (will call _process_next_batch_item on finish via _on_caption_finished)
-        QTimer.singleShot(100, self._generate_caption)
+        QTimer.singleShot(100, self._start_deferred_batch_caption)
+
+    def _start_deferred_batch_caption(self):
+        """Fire the next batch caption, unless the batch was cancelled.
+
+        There's a ~100 ms gap between batch items where _is_generating is
+        already False; if the user cancels in that window, _batch_active is
+        cleared. Guard here so the queued timer doesn't start an orphan
+        generation on the last-selected image after cancellation.
+        """
+        if self._batch_active:
+            self._generate_caption()
 
     def _on_batch_complete(self):
         """Handle batch completion."""

--- a/tests/test_mlx_engine.py
+++ b/tests/test_mlx_engine.py
@@ -6,6 +6,8 @@ An MLX model is a directory holding ``config.json`` plus at least one
 
 import sys
 
+import pytest
+
 from engine.mlx_engine import (
     MLX_SUPPORTED,
     _stream_with_sampling,
@@ -147,3 +149,53 @@ def test_stream_with_sampling_legacy_when_no_make_sampler():
     assert captured["kwargs"]["temperature"] == 0.0
     assert captured["kwargs"]["top_p"] == 1.0
     assert "sampler" not in captured["kwargs"]
+
+
+def test_stream_with_sampling_propagates_unrelated_typeerror():
+    # A TypeError from stream_generate that is NOT about the `sampler` kwarg is
+    # a genuine error and must propagate, not silently retry legacy kwargs.
+    legacy_called = {"hit": False}
+
+    def fake_make_sampler(temp, top_p):
+        return "sampler"
+
+    def fake_stream_generate(*args, **kwargs):
+        if "sampler" in kwargs:
+            raise TypeError("internal explosion unrelated to sampling")
+        legacy_called["hit"] = True
+        return iter(["legacy"])
+
+    with pytest.raises(TypeError, match="internal explosion"):
+        _stream_with_sampling(
+            fake_stream_generate,
+            ("m", "p", "prompt"),
+            {"max_tokens": 10},
+            0.6,
+            0.9,
+            make_sampler=fake_make_sampler,
+        )
+    assert legacy_called["hit"] is False
+
+
+def test_stream_with_sampling_propagates_make_sampler_error():
+    # If make_sampler() itself fails, that must surface — falling back to legacy
+    # kwargs on a newer mlx-vlm would reintroduce the crash this guards against.
+    legacy_called = {"hit": False}
+
+    def fake_make_sampler(temp, top_p):
+        raise TypeError("make_sampler signature mismatch")
+
+    def fake_stream_generate(*args, **kwargs):
+        legacy_called["hit"] = True
+        return iter(["legacy"])
+
+    with pytest.raises(TypeError, match="make_sampler"):
+        _stream_with_sampling(
+            fake_stream_generate,
+            ("m", "p", "prompt"),
+            {"max_tokens": 10},
+            0.6,
+            0.9,
+            make_sampler=fake_make_sampler,
+        )
+    assert legacy_called["hit"] is False

--- a/tests/test_mlx_engine.py
+++ b/tests/test_mlx_engine.py
@@ -6,7 +6,11 @@ An MLX model is a directory holding ``config.json`` plus at least one
 
 import sys
 
-from engine.mlx_engine import MLX_SUPPORTED, is_mlx_model_dir
+from engine.mlx_engine import (
+    MLX_SUPPORTED,
+    _stream_with_sampling,
+    is_mlx_model_dir,
+)
 
 
 def _make_mlx_folder(path):
@@ -56,3 +60,90 @@ def test_mlx_supported_matches_platform():
 
     expected = sys.platform == "darwin" and platform.machine() == "arm64"
     assert MLX_SUPPORTED == expected
+
+
+# --- _stream_with_sampling: version-tolerant mlx-vlm dispatch ---------------
+
+
+def test_stream_with_sampling_uses_sampler_when_supported():
+    captured = {}
+
+    def fake_make_sampler(temp, top_p):
+        captured["sampler_args"] = (temp, top_p)
+        return ("sampler", temp, top_p)
+
+    def fake_stream_generate(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        return iter(["ok"])
+
+    out = list(
+        _stream_with_sampling(
+            fake_stream_generate,
+            ("model", "processor", "prompt"),
+            {"image": ["x"], "max_tokens": 10},
+            0.6,
+            0.9,
+            make_sampler=fake_make_sampler,
+        )
+    )
+
+    assert out == ["ok"]
+    assert captured["sampler_args"] == (0.6, 0.9)
+    assert "sampler" in captured["kwargs"]
+    assert "temperature" not in captured["kwargs"]
+    assert "top_p" not in captured["kwargs"]
+    # Non-sampling kwargs are still forwarded.
+    assert captured["kwargs"]["max_tokens"] == 10
+
+
+def test_stream_with_sampling_falls_back_to_legacy_kwargs():
+    captured = {}
+
+    def fake_make_sampler(temp, top_p):
+        return "sampler"
+
+    def fake_stream_generate(*args, **kwargs):
+        # Emulate an older build whose signature has no `sampler` parameter.
+        if "sampler" in kwargs:
+            raise TypeError("unexpected keyword argument 'sampler'")
+        captured["kwargs"] = kwargs
+        return iter(["legacy"])
+
+    out = list(
+        _stream_with_sampling(
+            fake_stream_generate,
+            ("model", "processor", "prompt"),
+            {"image": ["x"], "max_tokens": 10},
+            0.6,
+            0.9,
+            make_sampler=fake_make_sampler,
+        )
+    )
+
+    assert out == ["legacy"]
+    assert captured["kwargs"]["temperature"] == 0.6
+    assert captured["kwargs"]["top_p"] == 0.9
+    assert "sampler" not in captured["kwargs"]
+
+
+def test_stream_with_sampling_legacy_when_no_make_sampler():
+    captured = {}
+
+    def fake_stream_generate(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        return iter(["x"])
+
+    list(
+        _stream_with_sampling(
+            fake_stream_generate,
+            (),
+            {},
+            0.0,
+            1.0,
+            make_sampler=None,
+        )
+    )
+
+    assert captured["kwargs"]["temperature"] == 0.0
+    assert captured["kwargs"]["top_p"] == 1.0
+    assert "sampler" not in captured["kwargs"]

--- a/tests/test_mlx_engine.py
+++ b/tests/test_mlx_engine.py
@@ -10,6 +10,7 @@ import pytest
 
 from engine.mlx_engine import (
     MLX_SUPPORTED,
+    _load_make_sampler,
     _stream_with_sampling,
     is_mlx_model_dir,
 )
@@ -62,6 +63,13 @@ def test_mlx_supported_matches_platform():
 
     expected = sys.platform == "darwin" and platform.machine() == "arm64"
     assert MLX_SUPPORTED == expected
+
+
+def test_load_make_sampler_never_raises():
+    # Returns None when mlx_lm is missing/too old (the common non-Mac case), or
+    # the callable factory if present — but must never raise.
+    result = _load_make_sampler()
+    assert result is None or callable(result)
 
 
 # --- _stream_with_sampling: version-tolerant mlx-vlm dispatch ---------------

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -1,0 +1,72 @@
+"""Tests for the mmproj auto-downloader (engine.model_downloader).
+
+These avoid the network by injecting a stub ``huggingface_hub`` module, so they
+also act as a regression guard: ``hf_hub_download`` must be called WITHOUT the
+``local_dir_use_symlinks`` argument, which is removed in huggingface_hub 1.0
+(the version this project targets) and raises TypeError there.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from engine.model_downloader import (
+    download_mmproj,
+    download_named_mmproj,
+    find_mmproj_file,
+)
+
+
+@pytest.fixture
+def stub_hf(monkeypatch):
+    """Install a fake huggingface_hub whose hf_hub_download records its kwargs."""
+    calls = []
+
+    def fake_hf_hub_download(**kwargs):
+        calls.append(kwargs)
+        dest = Path(kwargs["local_dir"]) / kwargs["filename"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"\x00")
+        return str(dest)
+
+    fake_mod = types.ModuleType("huggingface_hub")
+    fake_mod.hf_hub_download = fake_hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_mod)
+    return calls
+
+
+def test_download_named_mmproj_omits_deprecated_symlink_kwarg(stub_hf, tmp_path):
+    result = download_named_mmproj("some/repo", "vision.mmproj.gguf", tmp_path)
+    assert len(stub_hf) == 1
+    kwargs = stub_hf[0]
+    assert "local_dir_use_symlinks" not in kwargs
+    assert kwargs["repo_id"] == "some/repo"
+    assert kwargs["filename"] == "vision.mmproj.gguf"
+    assert kwargs["local_dir"] == str(tmp_path)
+    assert result.name == "vision.mmproj.gguf"
+
+
+def test_download_mmproj_omits_deprecated_symlink_kwarg(stub_hf, tmp_path):
+    download_mmproj(tmp_path)
+    assert stub_hf, "expected hf_hub_download to be called"
+    for kwargs in stub_hf:
+        assert "local_dir_use_symlinks" not in kwargs
+
+
+def test_find_mmproj_file_locates_mmproj(tmp_path):
+    (tmp_path / "model.Q4_K_M.gguf").write_bytes(b"\x00")
+    (tmp_path / "model.mmproj-f16.gguf").write_bytes(b"\x00")
+    found = find_mmproj_file(tmp_path)
+    assert found is not None
+    assert "mmproj" in found.name.lower()
+
+
+def test_find_mmproj_file_none_when_absent(tmp_path):
+    (tmp_path / "model.Q4_K_M.gguf").write_bytes(b"\x00")
+    assert find_mmproj_file(tmp_path) is None
+
+
+def test_find_mmproj_file_none_for_missing_dir(tmp_path):
+    assert find_mmproj_file(tmp_path / "does-not-exist") is None


### PR DESCRIPTION
## Summary

A focused code review (four parallel passes over the engine, downloader, and GUI) on top of the freshly restored test suite. Every change below is a **traced correctness bug**, not a style nit. Each was verified against the actual code, and the high-value ones are covered by new tests.

## Fixes

| Severity | File | Bug | Fix |
|---|---|---|---|
| **High** | `engine/model_downloader.py` | `hf_hub_download(local_dir_use_symlinks=False)` (×2) — this kwarg is **removed in `huggingface_hub` 1.0**, the version this module's header targets; passing it raises `TypeError` and breaks *every* mmproj download. | Drop the arg (modern `local_dir` already copies real files, so behavior is unchanged on older hub too). |
| **High** | `engine/mlx_engine.py` | `stream_generate(temperature=, top_p=)` — newer `mlx-vlm`/`mlx-lm` **dropped these kwargs** for a `sampler` callable. The project pins only `mlx-vlm>=0.1.0`, so a fresh `setup.sh` pulls the new API and **crashes on every caption**. | Version-tolerant dispatch: prefer a `make_sampler()` sampler, fall back to legacy kwargs. Works on either API. |
| **Medium** | `gui/main_window.py` | Batch-cancel race: the 100 ms inter-item `QTimer` fired `_generate_caption` even after cancel → orphan generation on the last image. | Guard the deferred call behind `_batch_active`. |
| **Medium** | `gui/main_window.py` | Generation `QThread` reassigned each batch item with no retention → "QThread destroyed while still running" risk. | Retain it in `_finished_threads`, mirroring the download path. |
| **Medium** | `gui/app_settings_dialog.py` | Toggling Dark Mode previews live, but **Cancel didn't revert it** — the running app disagreed with the unchanged saved config. | Re-emit the original theme on `reject()`. |
| **Low** | `gui/caption_panel.py` | Copy button restored its glyph from live button text, so a 2nd click within the 2 s window captured the checkmark and left the button stuck on it. | Restore the fixed clipboard glyph. |
| **Low** | `gui/image_viewer.py` | `_fit_to_view` set zoom with no lower clamp → a degenerate view size could yield a zero/negative zoom + blank image. | Clamp to a `0.1` floor (as `_set_zoom` does). |

## Tests (+8, suite now 89 passing)

- `tests/test_model_downloader.py` — stubs `huggingface_hub` and asserts `hf_hub_download` is called **without** `local_dir_use_symlinks` (regression guard for the hub-1.0 break), plus `find_mmproj_file` logic.
- `tests/test_mlx_engine.py` — `_stream_with_sampling` dispatch: sampler path used when supported, legacy-kwargs fallback when `sampler` is rejected, and the no-sampler path.

## Verification

Exact CI steps run locally (Python 3.11, `QT_QPA_PLATFORM=offscreen`): `compileall` ✓, `pyflakes` ✓, `pytest` → **89 passed**. All six edited modules (incl. `gui/main_window.py`) import cleanly headless.

> Note: the MLX sampler change is platform-gated (Apple Silicon) so it can't be exercised on the Linux CI runner — but the fallback preserves the current behavior, and the dispatch logic itself is unit-tested with fakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMYNNVhD1EvDD8oQ3bvhpT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMYNNVhD1EvDD8oQ3bvhpT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings dialog now reverts theme preview changes when cancelled

* **Bug Fixes**
  * Fixed batch caption generation to prevent orphaned operations
  * Fixed image viewer zoom limits for fit-to-view display
  * Improved MLX engine compatibility with newer sampling API
  * Enhanced visual feedback when copying captions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->