### PR TITLE
Fix CI regression + sync pyproject.toml dependencies

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -39,9 +39,10 @@ jobs:
 
       - name: Doctor report (informational — runner has no GPU, problems expected)
         # doctor.py exits non-zero when it finds problems (always true on a
-        # GPU-less CI runner). Swallow the exit code so this informational step
-        # doesn't surface a misleading "exit code 1" annotation on a passing run.
-        run: python doctor.py || echo "(doctor reported issues — expected on a GPU-less runner)"
+        # GPU-less CI runner). continue-on-error lets GitHub Actions show the
+        # step output without failing the job.
+        run: python doctor.py
+        continue-on-error: true
 
       - name: Headless app import (exercises the no-CUDA startup path)
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,10 @@ dependencies = [
     "llama-cpp-python>=0.3.0",
     "PyQt6>=6.7",
     "Pillow>=10.0",
-    "huggingface-hub>=0.25",
+    "huggingface-hub>=0.32",
+    "hf_xet>=1.0",
     "numpy>=1.26",
-    "pynvml>=11.0",
+    "nvidia-ml-py>=12.0",
     "psutil>=5.9",
 ]
 


### PR DESCRIPTION
## What

- **Fixes broken Windows Smoke CI** (regression from cc2f50e): reverts the doctor step from `|| echo` (doesn't reliably swallow exit codes in PowerShell) back to `continue-on-error: true` — the correct GitHub Actions idiom for steps that always exit non-zero on GPU-less runners.
- **Syncs `pyproject.toml` with `requirements.txt`**:
  - `pynvml>=11.0` → `nvidia-ml-py>=12.0` (official package, no deprecation warning)
  - `huggingface-hub>=0.25` → `>=0.32` (version parity)
  - Adds `hf_xet>=1.0` (Rust Xet client; already in requirements.txt)

## Also done (outside this PR)

- Deleted stale `fix/wheel-rollback-0.3.24` remote branch (contingency from pre-v1.4.0, superseded by v1.4.1)
- Closed issue #10 with explanation that CUDA 13.x is already auto-detected by `setup.bat`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows smoke-test reporting so failures are shown more clearly without suppressing test output.

* **Chores**
  * Updated dependency requirements to newer compatible versions, including Hugging Face and NVIDIA-related packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->