### PR TITLE
Security: bump Pillow floor to >=12.2.0 (5 CVEs)

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -39,9 +39,10 @@ jobs:
 
       - name: Doctor report (informational — runner has no GPU, problems expected)
         # doctor.py exits non-zero when it finds problems (always true on a
-        # GPU-less CI runner). Swallow the exit code so this informational step
-        # doesn't surface a misleading "exit code 1" annotation on a passing run.
-        run: python doctor.py || echo "(doctor reported issues — expected on a GPU-less runner)"
+        # GPU-less CI runner). continue-on-error lets GitHub Actions show the
+        # step output without failing the job.
+        run: python doctor.py
+        continue-on-error: true
 
       - name: Headless app import (exercises the no-CUDA startup path)
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     "llama-cpp-python>=0.3.0",
     "PyQt6>=6.7",
-    "Pillow>=10.0",
+    "Pillow>=12.2.0",
     "huggingface-hub>=0.32",
     "hf_xet>=1.0",
     "numpy>=1.26",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,10 @@ dependencies = [
     "llama-cpp-python>=0.3.0",
     "PyQt6>=6.7",
     "Pillow>=10.0",
-    "huggingface-hub>=0.25",
+    "huggingface-hub>=0.32",
+    "hf_xet>=1.0",
     "numpy>=1.26",
-    "pynvml>=11.0",
+    "nvidia-ml-py>=12.0",
     "psutil>=5.9",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # For llama-cpp-python with CUDA, see README.md for special instructions.
 
 PyQt6>=6.7
-Pillow>=10.0
+Pillow>=12.2.0
 huggingface-hub>=0.32
 hf_xet>=1.0  # Rust Xet client; high-performance hf_hub_download/snapshot_download
 numpy>=1.26


### PR DESCRIPTION
## What

Bumps the minimum Pillow version from `>=10.0` to `>=12.2.0` in both `requirements.txt` and `pyproject.toml`.

## Why

Pillow `<12.2.0` has 5 known vulnerabilities, all fixed in `12.2.0`:

| Severity | GHSA ID | Summary |
|----------|---------|---------|
| 🔴 HIGH | GHSA-pwv6-vv43-88gr | OOB write with invalid PSD tile extents (integer overflow) |
| 🔴 HIGH | GHSA-whj4-6x5x-4v2j | FITS GZIP decompression bomb |
| 🔴 HIGH | GHSA-cfh3-3jmp-rvhc | OOB write when loading PSD images |
| 🟡 MODERATE | GHSA-r73j-pqj5-w3x7 | PDF parsing trailer infinite loop (DoS) |
| 🟡 MODERATE | GHSA-wjx4-4jcj-g98j | Integer overflow when processing fonts |

With our old `>=10.0` floor, users could install any Pillow version from 10.0 to 12.1.x and be exposed to these vulnerabilities when the app loads or processes images.

## All other deps: clean ✅

| Package | Floor | Status |
|---------|-------|--------|
| numpy | >=1.26 | ✅ All CVEs are in <1.22 range |
| psutil | >=5.9 | ✅ CVE is in <=5.6.5 range |
| llama-cpp-python | >=0.3.0 | ✅ Critical RCE is in <=0.2.71 range |
| PyQt6, huggingface-hub, hf_xet, nvidia-ml-py | — | ✅ No advisories found |