### PR TITLE
Add SECURITY.md, update CHANGELOG for v1.4.2

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -39,9 +39,10 @@ jobs:
 
       - name: Doctor report (informational — runner has no GPU, problems expected)
         # doctor.py exits non-zero when it finds problems (always true on a
-        # GPU-less CI runner). Swallow the exit code so this informational step
-        # doesn't surface a misleading "exit code 1" annotation on a passing run.
-        run: python doctor.py || echo "(doctor reported issues — expected on a GPU-less runner)"
+        # GPU-less CI runner). continue-on-error lets GitHub Actions show the
+        # step output without failing the job.
+        run: python doctor.py
+        continue-on-error: true
 
       - name: Headless app import (exercises the no-CUDA startup path)
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/); versions correspond to
 git tags (`V1.x.x`).
 
+## [1.4.2] — 2026-06-24
+
+Security and dependency maintenance release. No new features.
+
+### Security
+- **Pillow floor bumped to >=12.2.0** — fixes 5 CVEs (2 HIGH, 3 MODERATE)
+  including integer overflow / OOB writes (PSD, fonts), a FITS decompression
+  bomb, and a PDF trailer DoS. Users on older Pillow builds were exposed when
+  loading images.
+
+### Changed
+- `nvidia-ml-py>=12.0` replaces deprecated `pynvml` package (same module, no
+  behaviour change — eliminates a FutureWarning on import).
+- `huggingface-hub>=0.32` floor raised; `hf_xet>=1.0` added as explicit
+  dependency (high-performance HuggingFace transfer was already used but not
+  pinned).
+
+### Infrastructure
+- CI doctor step (`continue-on-error`) restored — Windows smoke test had
+  regressed to always-fail after a PowerShell incompatibility.
+- Added `SECURITY.md` with private vulnerability reporting instructions.
+
+---
+
 ## [1.4.1] — 2026-06-16
 
 Hardening release from a deep multi-agent code review (19 confirmed findings,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release is actively maintained with security fixes.
+
+| Version | Supported |
+|---------|-----------|
+| 1.4.x (latest) | ✅ |
+| < 1.4.0 | ❌ |
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+To report a vulnerability privately:
+
+1. Go to the [Security tab](https://github.com/GitDonkeyHubbed/qwen3vl-captioner/security) of this repository.
+2. Click **"Report a vulnerability"** to open a private advisory draft.
+3. Describe the issue, steps to reproduce, and any potential impact.
+
+You can expect an acknowledgment within **72 hours** and a fix or workaround within **14 days** for confirmed issues.
+
+## Scope
+
+This is a local desktop application — it does not run a server, expose ports, or process untrusted remote input by design. The most relevant security surface is the dependency chain (Python packages). Dependency vulnerabilities are scanned regularly and patched promptly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     "llama-cpp-python>=0.3.0",
     "PyQt6>=6.7",
-    "Pillow>=10.0",
+    "Pillow>=12.2.0",
     "huggingface-hub>=0.32",
     "hf_xet>=1.0",
     "numpy>=1.26",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,10 @@ dependencies = [
     "llama-cpp-python>=0.3.0",
     "PyQt6>=6.7",
     "Pillow>=10.0",
-    "huggingface-hub>=0.25",
+    "huggingface-hub>=0.32",
+    "hf_xet>=1.0",
     "numpy>=1.26",
-    "pynvml>=11.0",
+    "nvidia-ml-py>=12.0",
     "psutil>=5.9",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # For llama-cpp-python with CUDA, see README.md for special instructions.
 
 PyQt6>=6.7
-Pillow>=10.0
+Pillow>=12.2.0
 huggingface-hub>=0.32
 hf_xet>=1.0  # Rust Xet client; high-performance hf_hub_download/snapshot_download
 numpy>=1.26


### PR DESCRIPTION
## What

- Adds `SECURITY.md` with private vulnerability reporting instructions (GitHub private advisory flow)
- Updates `CHANGELOG.md` with the v1.4.2 entry covering all changes since v1.4.1

## Why

- GitHub shows a "Security policy" badge on the repo once `SECURITY.md` is present — tells users how to report issues without posting them publicly
- CHANGELOG keeps users informed about what changed in each release