### PR TITLE
Repo health check: version sync + bug/consistency fixes (v1.4.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,6 @@ env/
 # ─── Development artifacts ────────────────────────────────
 *.log
 nul
-0.3.0
-1.26
 llama-cpp-python-build/
 ENGINEERING_NOTES.md
 FIX_SUMMARY.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to this project are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/); versions correspond to
 git tags (`V1.x.x`).
 
+## [1.4.3] — Unreleased
+
+Maintenance release from a full repository health check (every finding
+adversarially verified against the source). No new features.
+
+### Fixed
+- **Version string lag.** `gui/version.py` and `pyproject.toml` were still
+  `1.4.1` after the 1.4.2 release, so the in-app "Check for Updates" reported a
+  phantom update to every up-to-date user. Versions are back in sync.
+- **GUI froze during a vision-encoder download.** When a model's `mmproj` was
+  missing, the Load flow downloaded it synchronously on the Qt UI thread,
+  freezing the window with no progress for the whole multi-hundred-MB transfer.
+  It now runs off-thread behind a responsive modal dialog.
+- **Shutdown safety.** Closing the window mid-download no longer risks
+  destroying a still-running download thread — the `wait()` result is honored
+  like the load/caption threads, and earlier shutting-down threads are joined
+  before the engine is freed.
+- **Download integrity.** A stale `.part` left under the same name by a
+  different file can no longer be silently appended onto and finalized as a
+  corrupt model — partials are validated against an identity sidecar before
+  resume. Downloads now also pre-flight free disk space and fail fast with a
+  clear message.
+- **Atomic config writes.** `config.json` is written to a temp file and
+  `os.replace`d into place, so an interrupted save can't truncate it (which
+  load silently discarded, losing the hf_token / custom models / theme).
+- **Caption robustness.** The non-streaming path no longer crashes when the
+  model returns `null` content; the streaming path tolerates an empty
+  `choices` list.
+- **Presets.** Toggling a preset off now restores the user's own
+  prefix/suffix instead of leaving the preset's tokens applied; the
+  "Refer-as name" field now emits `settings_changed` like other inputs.
+- **Deterministic encoder pick.** `find_mmproj_file` sorts (preferring `f16`)
+  when a folder holds more than one encoder, instead of relying on filesystem
+  order.
+- **Misc.** `diagnose.bat` now evaluates `where python` correctly (delayed
+  expansion); removed two stray `.gitignore` patterns; the `mlx` extra floor is
+  raised to `mlx-vlm>=0.6` to match the shipped next-gen MLX models.
+
+### Docs
+- README MLX lineup, "default quant" wording, version header, and
+  project-structure tree corrected; `CONTRIBUTING.md` now points at the real
+  registry test (`tests/test_model_registry.py`).
+
+### Known limitations
+- Cancelling an MLX folder (snapshot) download still only takes effect between
+  files — a large shard already in flight must finish first — but the UI now
+  says so instead of looking hung.
+
+---
+
 ## [1.4.2] — 2026-06-24
 
 Security and dependency maintenance release. No new features.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,8 +90,8 @@ the dropdown. **Always pair a model with the `mmproj` published in its own repo*
 built in (no `mmproj`). Add an entry to `_MLX_ABL` / `_MLX_STD` / `_MLX_NEXTGEN`
 with `repo_id`, `folder`, `size_gb`, and `"backend": "mlx"`.
 
-After editing the registry, run the tests — `tests/test_core.py` checks registry
-integrity (every entry resolves, has a valid mmproj, etc.).
+After editing the registry, run the tests — `tests/test_model_registry.py` checks
+registry integrity (every entry resolves, has a valid mmproj, etc.).
 
 ## Project layout
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
   <img src="assets/VL_GGUF_Captioner GUI Screenshot 2.png" alt="QWEN 3 VL ABL Captioner" width="900"/>
 </p>
 
-<h1 align="center">QWEN 3 VL ABL Captioner V1.4.2 — GGUF + MLX Engines</h1>
+<h1 align="center">QWEN 3 VL ABL Captioner V1.4.3 — GGUF + MLX Engines</h1>
 <h3 align="center">Professional GPU-Accelerated Image Captioning for Datasets</h3>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.4.2-blue" alt="Version"/>
+  <img src="https://img.shields.io/badge/version-1.4.3-blue" alt="Version"/>
   <img src="https://img.shields.io/badge/python-3.12-blue?logo=python" alt="Python"/>
   <img src="https://img.shields.io/badge/GPU-CUDA%2012.4%E2%80%9313.x-green?logo=nvidia" alt="CUDA"/>
   <img src="https://img.shields.io/badge/Apple%20Silicon-Metal%20%2B%20MLX-black?logo=apple" alt="Apple Silicon"/>
@@ -41,6 +41,18 @@
 
 ---
 
+## 🩺 What's New in V1.4.3 — Health-Check Fixes
+
+No new features — a sweep of bug and consistency fixes from a full repository health check.
+
+- **No more phantom "update available" popup** — the in-app version was stuck at 1.4.1 and now matches the build.
+- **The window no longer freezes** while downloading a model's vision encoder — it runs in the background behind a progress dialog instead of going *Not Responding*.
+- **Safer downloads & settings** — an interrupted download can no longer be finalized as a corrupt model, downloads check free disk space first, and `config.json` is written atomically so a crash can't wipe your token/settings.
+- **Preset fix** — turning a preset off now restores *your* prefix/suffix instead of leaving the preset's tags applied.
+- Plus smaller robustness fixes (caption edge cases, deterministic encoder pick, a `diagnose.bat` bug, and doc corrections).
+
+---
+
 ## 🔒 What's New in V1.4.2 — Security & Dependency Maintenance
 
 No new features — just keeping things safe and clean for everyone.
@@ -69,7 +81,7 @@ The model dropdown is reorganized into groups (newest first):
 - **Qwen3-VL 8B Caption-it** — an abliterated fine-tune [specialized for image captioning](https://huggingface.co/prithivMLmods/Qwen3-VL-8B-Abliterated-Caption-it-GGUF)
 - **Huihui Qwen3-VL 8B ABL** — [huihui-ai's abliteration](https://huggingface.co/noctrex/Huihui-Qwen3-VL-8B-Instruct-abliterated-GGUF) (quantized by noctrex)
 - **Legacy v1** — kept for existing installs
-- **MLX (Apple Silicon): abliterated** ([alexgusevski's conversions](https://huggingface.co/alexgusevski/Huihui-Qwen3-VL-8B-Instruct-abliterated-q4-mlx)) **and standard** quants, plus an experimental **Qwen3.5 4B abliterated VLM**
+- **MLX (Apple Silicon)** — several groups in the dropdown: **Abliterated v2** (Qwen3-VL 8B, 4/6/8-bit — the recommended Mac default), **Gliese Caption** (Qwen3.5, 0.8B–9B, captioning-tuned), **Qwen3-VL c_abliterated** (newest), plus **huihui abliterated**, **standard**, and an experimental **Qwen3.5** group
 
 Downloading a model now also **auto-downloads its matching mmproj** (vision encoder) when none is present.
 
@@ -189,7 +201,7 @@ Download models directly inside the app (✓ marks the ones you already have), o
 
 | Your setup | Recommended pick |
 |---|---|
-| 12 GB+ VRAM (RTX 3060+) | **Qwen3-VL 8B ABL v2 — Q6_K** *(the default)* |
+| 12 GB+ VRAM (RTX 3060+) | **Qwen3-VL 8B ABL v2 — Q6_K** *(typical pick; the app auto-selects the best quant for your VRAM)* |
 | 8 GB VRAM | Qwen3-VL 8B ABL v2 — Q4_K_M |
 | Low VRAM / older GPU | Qwen3-VL 8B ABL v2 — Q2_K |
 | Best caption quality | Qwen3-VL 8B Caption-it — Q6_K *(captioning-tuned)* |
@@ -253,6 +265,7 @@ qwen3vl-captioner/
 │   ├── dataset_panel.py    # Dataset table view
 │   ├── theme.py            # Dark/light theme color system & QSS stylesheet
 │   ├── config.py           # User config persistence (~/.vlcaptioner/)
+│   ├── version.py          # single source of truth for APP_VERSION
 │   ├── notification_panel.py
 │   ├── app_settings_dialog.py
 │   └── model_download_manager.py

--- a/diagnose.bat
+++ b/diagnose.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal enabledelayedexpansion
 cd /d "%~dp0"
 
 echo Running install diagnostics...
@@ -10,7 +11,7 @@ if exist ".venv\Scripts\python.exe" (
     echo [WARN] Virtual environment not found - run setup.bat first.
     echo        Trying system Python as a fallback...
     where python >nul 2>&1
-    if %ERRORLEVEL% EQU 0 (
+    if !ERRORLEVEL! EQU 0 (
         python doctor.py
     ) else (
         echo [FAIL] No Python found. Run setup.bat first.

--- a/engine/inference.py
+++ b/engine/inference.py
@@ -258,7 +258,8 @@ class Qwen3VLEngine:
                 stream=False,
             )
             
-            message = response["choices"][0]["message"]
+            choices = response.get("choices") or [{}]
+            message = (choices[0] or {}).get("message") or {}
             caption = (message.get("content") or "").strip()
         
         self._last_inference_time = time.perf_counter() - start_time

--- a/engine/inference.py
+++ b/engine/inference.py
@@ -240,7 +240,8 @@ class Qwen3VLEngine:
                 if cancel_check and cancel_check():
                     break
                 
-                delta = chunk.get("choices", [{}])[0].get("delta", {})
+                choices = chunk.get("choices") or [{}]
+                delta = choices[0].get("delta", {})
                 token_text = delta.get("content", "")
                 if token_text:
                     caption_parts.append(token_text)
@@ -257,7 +258,8 @@ class Qwen3VLEngine:
                 stream=False,
             )
             
-            caption = response["choices"][0]["message"]["content"].strip()
+            message = response["choices"][0]["message"]
+            caption = (message.get("content") or "").strip()
         
         self._last_inference_time = time.perf_counter() - start_time
 

--- a/engine/model_downloader.py
+++ b/engine/model_downloader.py
@@ -55,13 +55,18 @@ def find_mmproj_file(model_dir: Path) -> Optional[Path]:
     """
     if not model_dir.is_dir():
         return None
-    
-    for f in model_dir.iterdir():
-        name_lower = f.name.lower()
-        if f.is_file() and f.suffix == ".gguf" and "mmproj" in name_lower:
-            return f
-    
-    return None
+
+    # A model folder can legitimately hold more than one encoder (e.g. an f16
+    # and a Q8_0 mmproj). iterdir() order is filesystem-dependent, so sort for
+    # a deterministic pick and prefer the higher-quality f16 when present.
+    matches = sorted(
+        (
+            f for f in model_dir.iterdir()
+            if f.is_file() and f.suffix == ".gguf" and "mmproj" in f.name.lower()
+        ),
+        key=lambda f: (0 if "f16" in f.name.lower() else 1, f.name.lower()),
+    )
+    return matches[0] if matches else None
 
 
 def download_mmproj(

--- a/gui/app_settings_dialog.py
+++ b/gui/app_settings_dialog.py
@@ -304,5 +304,12 @@ class AppSettingsDialog(QDialog):
     def _save_and_close(self):
         self._cfg["theme"] = "dark" if self._dark_mode_cb.isChecked() else "light"
         self._cfg["hf_token"] = self._token_input.text().strip()
-        save_config(self._cfg)
+        if not save_config(self._cfg):
+            from PyQt6.QtWidgets import QMessageBox
+            QMessageBox.warning(
+                self, "Save Failed",
+                "Could not save your settings to disk — the location may be "
+                "full or read-only. Your changes have not been persisted.",
+            )
+            return  # keep the dialog open so the user can retry
         self.accept()

--- a/gui/config.py
+++ b/gui/config.py
@@ -45,22 +45,28 @@ def load_config() -> Dict[str, Any]:
     return cfg
 
 
-def save_config(cfg: Dict[str, Any]):
+def save_config(cfg: Dict[str, Any]) -> bool:
     """Persist the full config dict to disk atomically.
 
     Write to a sibling temp file and os.replace() it into place so an
     interrupted write (crash, power loss) can never leave config.json
     truncated — which load_config() would silently discard, losing the
     user's hf_token, custom_models, theme, and auto_save settings.
+
+    Returns True on success and False if the write/replace failed (e.g. the
+    disk is full or the location is read-only), so callers that care — like
+    the settings dialog — can surface the failure instead of assuming the
+    save succeeded.
     """
-    _ensure_dir()
     try:
+        _ensure_dir()
         tmp = _CONFIG_FILE.with_suffix(".json.tmp")
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(cfg, f, indent=2)
         os.replace(tmp, _CONFIG_FILE)
+        return True
     except Exception:
-        pass  # best-effort
+        return False  # best-effort; caller may surface this
 
 
 def get_hf_token() -> str:

--- a/gui/config.py
+++ b/gui/config.py
@@ -6,6 +6,7 @@ Stores settings as JSON in ~/.vlcaptioner/config.json.
 
 import copy
 import json
+import os
 from pathlib import Path
 from typing import Any, Dict
 
@@ -45,11 +46,19 @@ def load_config() -> Dict[str, Any]:
 
 
 def save_config(cfg: Dict[str, Any]):
-    """Persist the full config dict to disk."""
+    """Persist the full config dict to disk atomically.
+
+    Write to a sibling temp file and os.replace() it into place so an
+    interrupted write (crash, power loss) can never leave config.json
+    truncated — which load_config() would silently discard, losing the
+    user's hf_token, custom_models, theme, and auto_save settings.
+    """
     _ensure_dir()
     try:
-        with open(_CONFIG_FILE, "w", encoding="utf-8") as f:
+        tmp = _CONFIG_FILE.with_suffix(".json.tmp")
+        with open(tmp, "w", encoding="utf-8") as f:
             json.dump(cfg, f, indent=2)
+        os.replace(tmp, _CONFIG_FILE)
     except Exception:
         pass  # best-effort
 

--- a/gui/dataset_panel.py
+++ b/gui/dataset_panel.py
@@ -166,9 +166,6 @@ class DatasetPanel(QFrame):
             if has_caption:
                 captioned += 1
             status_item = QTableWidgetItem("Yes" if has_caption else "No")
-            status_item.setForeground(
-                QPixmap(1, 1).toImage().pixelColor(0, 0)  # placeholder — set via stylesheet
-            )
             if has_caption:
                 status_item.setForeground(Qt.GlobalColor.green)
             else:

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -14,11 +14,11 @@ import traceback
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from PyQt6.QtCore import Qt, QThread, pyqtSignal, QObject, QTimer
+from PyQt6.QtCore import Qt, QThread, QEventLoop, pyqtSignal, QObject, QTimer
 from PyQt6.QtWidgets import (
     QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
     QFrame, QSplitter, QStatusBar, QProgressBar, QApplication, QFileDialog,
-    QMessageBox, QSizePolicy, QStackedWidget,
+    QMessageBox, QSizePolicy, QStackedWidget, QProgressDialog,
 )
 
 from gui.file_browser import FileBrowserPanel
@@ -55,6 +55,34 @@ class ModelLoadWorker(QObject):
             self.finished.emit()
         except Exception as e:
             self.error.emit(f"{e}\n{traceback.format_exc()}")
+
+
+# --- Worker for a blocking download run on a background thread ---
+class _BlockingDownloadWorker(QObject):
+    """Runs a blocking download callable on a QThread.
+
+    The callable receives a ``progress_callback(message, fraction)`` and
+    returns its result (e.g. a Path). Used to move the vision-encoder
+    (mmproj) download off the Qt UI thread so the window stays responsive
+    while it runs (see MainWindow._download_mmproj_blocking).
+    """
+    progress = pyqtSignal(str)
+    finished = pyqtSignal(object)   # result of the callable
+    error = pyqtSignal(str)
+
+    def __init__(self, fn):
+        super().__init__()
+        self._fn = fn
+
+    def run(self):
+        try:
+            result = self._fn(
+                lambda msg, _f=None: self.progress.emit(str(msg))
+            )
+        except Exception as e:
+            self.error.emit(str(e))
+            return
+        self.finished.emit(result)
 
 
 # --- Worker for background caption generation ---
@@ -644,11 +672,11 @@ class MainWindow(QMainWindow):
     def _load_model(self):
         """Load the selected model, guarding against re-entrant loads.
 
-        The mmproj dialogs / synchronous encoder download in the implementation
-        spin the Qt event loop while is_loaded is still False and the Load
-        button is enabled, so a second trigger could otherwise start a second
-        concurrent load on a single engine (racing self.model assignment). The
-        _is_loading flag prevents that.
+        The mmproj dialogs and the modal encoder-download dialog in the
+        implementation spin the Qt event loop while is_loaded is still False
+        and the Load button is enabled, so a second trigger could otherwise
+        start a second concurrent load on a single engine (racing self.model
+        assignment). The _is_loading flag prevents that.
         """
         if self._is_loading or (self._model_load_thread and self._model_load_thread.isRunning()):
             return
@@ -721,6 +749,64 @@ class MainWindow(QMainWindow):
             return None
         return get_model_info(value)
 
+    def _download_mmproj_blocking(self, title, fn):
+        """Run a blocking mmproj download off the UI thread.
+
+        ``fn`` takes a ``progress_callback(message, fraction)`` and returns the
+        downloaded Path. The work runs on a QThread while a modal, indeterminate
+        progress dialog spins a local event loop, so the main window keeps
+        repainting (no 'Not Responding') instead of freezing for the whole
+        multi-hundred-MB encoder transfer. Returns the Path, or re-raises the
+        worker's exception so the caller's existing error handling applies.
+        """
+        thread = QThread()
+        worker = _BlockingDownloadWorker(fn)
+        worker.moveToThread(thread)
+
+        dialog = QProgressDialog(
+            f"{title}\nThis can take a while for large encoders…",
+            None, 0, 0, self,   # no Cancel button; 0/0 = indeterminate
+        )
+        dialog.setWindowTitle("Downloading Vision Encoder")
+        dialog.setWindowModality(Qt.WindowModality.ApplicationModal)
+        dialog.setMinimumDuration(0)
+        dialog.setAutoClose(False)
+        dialog.setAutoReset(False)
+
+        loop = QEventLoop()
+        state = {"result": None, "error": None}
+
+        def on_progress(msg):
+            dialog.setLabelText(msg)
+            self._settings_panel.set_model_status(msg)
+
+        def on_finished(result):
+            state["result"] = result
+            loop.quit()
+
+        def on_error(msg):
+            state["error"] = msg
+            loop.quit()
+
+        worker.progress.connect(on_progress)
+        worker.finished.connect(on_finished)
+        worker.error.connect(on_error)
+        worker.finished.connect(thread.quit)
+        worker.error.connect(thread.quit)
+        thread.started.connect(worker.run)
+
+        thread.start()
+        dialog.show()
+        loop.exec()            # keeps the UI alive until the worker signals done
+        dialog.close()
+
+        thread.quit()
+        thread.wait(5000)
+
+        if state["error"] is not None:
+            raise RuntimeError(state["error"])
+        return state["result"]
+
     def _resolve_missing_mmproj(self, model_dir, info, expected_mmproj):
         """Obtain a vision encoder when the one matching the model isn't on disk.
 
@@ -751,9 +837,12 @@ class MainWindow(QMainWindow):
                     self._settings_panel.set_model_status(
                         "Downloading matching vision encoder..."
                     )
-                    return download_named_mmproj(
-                        info["repo_id"], expected_mmproj, model_dir,
-                        progress_callback=lambda msg, _f: self._settings_panel.set_model_status(msg),
+                    return self._download_mmproj_blocking(
+                        f"Downloading matching vision encoder ({expected_mmproj})…",
+                        lambda cb: download_named_mmproj(
+                            info["repo_id"], expected_mmproj, model_dir,
+                            progress_callback=cb,
+                        ),
                     )
                 except Exception as e:
                     QMessageBox.critical(
@@ -788,9 +877,9 @@ class MainWindow(QMainWindow):
         )
         if answer == QMessageBox.StandardButton.Yes:
             try:
-                return ensure_mmproj(
-                    model_dir,
-                    progress_callback=lambda msg, _f: self._settings_panel.set_model_status(msg),
+                return self._download_mmproj_blocking(
+                    "Downloading default vision encoder…",
+                    lambda cb: ensure_mmproj(model_dir, progress_callback=cb),
                 )
             except Exception as e:
                 QMessageBox.critical(
@@ -1104,7 +1193,15 @@ class MainWindow(QMainWindow):
         self._download_worker.cancel()
         self._dl_stop_btn.setEnabled(False)
         self._dl_stop_btn.setText("Stopping…")
-        self._notify("Stopping download…", "info")
+        # An MLX folder (snapshot) download can only stop between files — a
+        # large shard already in flight has to finish first — so be honest
+        # about the delay instead of looking hung.
+        if getattr(self._download_worker, "snapshot_folder", None):
+            msg = "Stopping after the current file finishes…"
+            self._queue_label.setText(msg)
+            self._notify(msg, "info")
+        else:
+            self._notify("Stopping download…", "info")
 
     def _hide_download_stop_btn(self):
         """Reset and hide the status-bar download Stop button."""
@@ -1766,12 +1863,24 @@ class MainWindow(QMainWindow):
                 threads_clean = False
 
         # Download: quit() alone can't stop the blocking run()/thread pool —
-        # signal cancel first so the worker threads actually exit.
+        # signal cancel first so the worker threads actually exit. Capture the
+        # wait() result like the other threads: a download stuck mid-shard must
+        # block unload() rather than be destroyed while still running.
         if self._download_thread and self._download_thread.isRunning():
             if self._download_worker:
                 self._download_worker.cancel()
             self._download_thread.quit()
-            self._download_thread.wait(10000)
+            if not self._download_thread.wait(10000):
+                threads_clean = False
+
+        # Any earlier download/generation threads still shutting down (kept alive
+        # in _finished_threads so they aren't GC'd mid-stop) must also be joined
+        # before unload(), so none is destroyed while still running.
+        for t in getattr(self, "_finished_threads", []):
+            if t.isRunning():
+                t.quit()
+                if not t.wait(10000):
+                    threads_clean = False
 
         # Only free the native engine objects once no worker can still be using
         # them. On a dirty exit (a wait timed out), skip unload() — the process

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -801,7 +801,14 @@ class MainWindow(QMainWindow):
         dialog.close()
 
         thread.quit()
-        thread.wait(5000)
+        # Wait without a timeout: loop.exec() only returns after the worker
+        # emitted finished/error (the last thing run() does), so the thread is
+        # already finishing. A bounded wait that timed out would let thread/
+        # worker fall out of scope while still running -> "QThread: Destroyed
+        # while thread is still running" and a possible crash. Once wait()
+        # returns the thread has fully stopped, so dropping the references on
+        # return is safe.
+        thread.wait()
 
         if state["error"] is not None:
             raise RuntimeError(state["error"])

--- a/gui/model_download_manager.py
+++ b/gui/model_download_manager.py
@@ -534,7 +534,11 @@ class ModelDownloadWorker(QObject):
                 free = shutil.disk_usage(probe_dir).free
             except Exception:
                 free = None
-            needed = total + 256 * 1024 * 1024  # 256 MiB headroom
+            # Only the not-yet-downloaded bytes need to fit: a resumable .part
+            # already on disk counts toward the file, so don't demand room for a
+            # second full copy (which would block a nearly-complete resume).
+            existing_part = part.stat().st_size if part.exists() else 0
+            needed = max(total - existing_part, 0) + 256 * 1024 * 1024  # +256 MiB headroom
             if free is not None and free < needed:
                 self.error.emit(
                     f"Not enough free disk space for {self.filename}: need "
@@ -823,11 +827,22 @@ class ModelDownloadWorker(QObject):
                 response = opener.open(request, timeout=self._SOCKET_TIMEOUT)
             except urllib.error.HTTPError as http_err:
                 if http_err.code == 416 and resume_pos:
-                    # Range beyond EOF — the .part file is already complete
-                    part.replace(target)
-                    self._safe_unlink(self._part_meta_path(part))
-                    self.progress.emit("Download complete", 1.0)
-                    self.finished.emit(str(target))
+                    # 416 = requested range unsatisfiable. Only treat the .part
+                    # as complete when its size matches the known remote total —
+                    # a 416 alone doesn't prove completeness (the probe may have
+                    # failed, or the .part may be oversized/corrupt). When we
+                    # can't verify, keep the .part for a future resume rather
+                    # than promoting possibly-corrupt data to the final file.
+                    if probed_total and resume_pos == probed_total:
+                        part.replace(target)
+                        self._safe_unlink(self._part_meta_path(part))
+                        self.progress.emit("Download complete", 1.0)
+                        self.finished.emit(str(target))
+                        return
+                    self.error.emit(
+                        "Could not verify the existing partial download; "
+                        "download again to retry."
+                    )
                     return
                 raise
 

--- a/gui/model_download_manager.py
+++ b/gui/model_download_manager.py
@@ -9,7 +9,9 @@ Provides:
 
 import concurrent.futures
 import importlib.util
+import json
 import os
+import shutil
 import threading
 import time
 import urllib.error
@@ -445,7 +447,6 @@ class ModelDownloadWorker(QObject):
 
         def _discard_partial():
             if not already_complete:
-                import shutil
                 shutil.rmtree(dest, ignore_errors=True)
 
         try:
@@ -520,6 +521,28 @@ class ModelDownloadWorker(QObject):
         # stream for small files, servers without Range support, or when a
         # resumable .part already exists.
         total, supports_range = self._probe(url)
+
+        # Pre-flight disk-space check so a multi-GB download fails fast with a
+        # clear message instead of dying mid-write — the parallel path even
+        # pre-allocates the full size, which can sparse-succeed and only fail
+        # later as opaque write errors.
+        if total:
+            probe_dir = self.target_dir
+            while not probe_dir.exists() and probe_dir != probe_dir.parent:
+                probe_dir = probe_dir.parent
+            try:
+                free = shutil.disk_usage(probe_dir).free
+            except Exception:
+                free = None
+            needed = total + 256 * 1024 * 1024  # 256 MiB headroom
+            if free is not None and free < needed:
+                self.error.emit(
+                    f"Not enough free disk space for {self.filename}: need "
+                    f"~{needed / 1024**3:.1f} GB, but only "
+                    f"{free / 1024**3:.1f} GB free at {probe_dir}."
+                )
+                return
+
         use_parallel = (
             supports_range
             and total >= self._PARALLEL_THRESHOLD
@@ -726,6 +749,43 @@ class ModelDownloadWorker(QObject):
         self.progress.emit("Download complete", 1.0)
         self.finished.emit(str(target))
 
+    @staticmethod
+    def _part_meta_path(part: Path) -> Path:
+        return part.with_name(part.name + ".meta")
+
+    def _write_part_identity(self, part: Path, total: int):
+        """Record which file this .part belongs to, so a later resume can tell
+        it apart from a stale .part left under the same name by a different
+        download (e.g. a different quant, or a renamed registry stem)."""
+        try:
+            self._part_meta_path(part).write_text(
+                json.dumps({
+                    "repo_id": self.repo_id,
+                    "filename": self.filename,
+                    "total": int(total or 0),
+                }),
+                encoding="utf-8",
+            )
+        except Exception:
+            pass
+
+    def _part_identity_matches(self, part: Path, probed_total: int) -> bool:
+        """True only if the .part's identity sidecar matches this exact
+        repo/file (and the recorded total size, when known)."""
+        try:
+            data = json.loads(
+                self._part_meta_path(part).read_text(encoding="utf-8")
+            )
+        except Exception:
+            return False
+        if (data.get("repo_id") != self.repo_id
+                or data.get("filename") != self.filename):
+            return False
+        recorded = int(data.get("total") or 0)
+        if recorded and probed_total and recorded != probed_total:
+            return False
+        return True
+
     def _run_single(self, url, target: Path, part: Path):
         """Download *url* into *part* over a single resumable connection."""
         try:
@@ -733,15 +793,22 @@ class ModelDownloadWorker(QObject):
 
             resume_pos = part.stat().st_size if part.exists() else 0
             if resume_pos:
-                # Guard against resuming onto a stale/oversized .part (e.g. one
-                # left by a different file with the same name): if it already
-                # exceeds the current remote size it can't be a valid partial of
-                # this file, so discard it and start fresh. Cheap probe, only on
-                # the resume path. (A .part exactly == total is kept and the 416
-                # branch below finalizes it.)
+                # Guard against resuming onto a stale/mismatched .part. Size
+                # alone can't prove a partial belongs to this file — a leftover
+                # .part from a *different* file under the same name that is
+                # SMALLER than the new remote file would otherwise be appended
+                # onto, producing a full-size but corrupt result. So discard the
+                # .part unless its identity sidecar matches this exact repo/file
+                # (and recorded size), or if it already exceeds the remote size.
+                # (A matching .part exactly == total is kept and the 416 branch
+                # below finalizes it.)
                 probed_total, _ = self._probe(url)
-                if probed_total and resume_pos > probed_total:
+                if (
+                    not self._part_identity_matches(part, probed_total)
+                    or (probed_total and resume_pos > probed_total)
+                ):
                     self._safe_unlink(part)
+                    self._safe_unlink(self._part_meta_path(part))
                     resume_pos = 0
             if resume_pos:
                 headers["Range"] = f"bytes={resume_pos}-"
@@ -758,6 +825,7 @@ class ModelDownloadWorker(QObject):
                 if http_err.code == 416 and resume_pos:
                     # Range beyond EOF — the .part file is already complete
                     part.replace(target)
+                    self._safe_unlink(self._part_meta_path(part))
                     self.progress.emit("Download complete", 1.0)
                     self.finished.emit(str(target))
                     return
@@ -781,11 +849,17 @@ class ModelDownloadWorker(QObject):
                 last_emit = 0.0
                 self.target_dir.mkdir(parents=True, exist_ok=True)
 
+                if resume_pos == 0:
+                    # Fresh .part — stamp its identity so a future resume can
+                    # confirm the partial belongs to this exact file.
+                    self._write_part_identity(part, total)
+
                 with open(part, mode) as f:
                     while True:
                         if self._cancelled:
                             # User cancelled — discard so a new model can be chosen
                             self._safe_unlink(part)
+                            self._safe_unlink(self._part_meta_path(part))
                             self.error.emit("Download cancelled.")
                             return
                         chunk = response.read(self._CHUNK_SIZE)
@@ -821,12 +895,14 @@ class ModelDownloadWorker(QObject):
                 return
 
             part.replace(target)
+            self._safe_unlink(self._part_meta_path(part))
             self.progress.emit("Download complete", 1.0)
             self.finished.emit(str(target))
 
         except Exception as exc:
             if self._cancelled:
                 self._safe_unlink(part)
+                self._safe_unlink(self._part_meta_path(part))
                 self.error.emit("Download cancelled.")
                 return
             self.error.emit(self._format_error(exc))

--- a/gui/settings_panel.py
+++ b/gui/settings_panel.py
@@ -500,6 +500,11 @@ class SettingsPanel(QFrame):
         self.setMaximumWidth(420)
 
         self._active_preset_id: Optional[str] = None
+        # The user's own prefix/suffix, stashed when entering preset mode so
+        # deselecting a preset restores them instead of leaving the preset's
+        # tokens (e.g. Pony's "score_9, ...") baked into the input fields.
+        self._user_prefix_before_preset: Optional[str] = None
+        self._user_suffix_before_preset: Optional[str] = None
         self._preset_buttons: Dict[str, QPushButton] = {}
         self._extra_checkboxes: Dict[str, QCheckBox] = {}
         self._show_extra_options = True
@@ -667,7 +672,11 @@ class SettingsPanel(QFrame):
             f"border: 1px solid {COLORS['border_light']}; border-radius: 4px; "
             f"padding: 4px 8px; font-size: 12px;"
         )
-        self.name_input.textChanged.connect(lambda _=None: self._refresh_prompt_preview())
+        # Emit settings_changed too (like every other prompt-affecting input),
+        # not just refresh the preview, so listeners see the name change.
+        self.name_input.textChanged.connect(
+            lambda _=None: (self._refresh_prompt_preview(), self.settings_changed.emit())
+        )
         layout.addWidget(self.name_input)
 
         layout.addWidget(self._separator())
@@ -815,7 +824,7 @@ class SettingsPanel(QFrame):
         )
         layout.addWidget(self.auto_save_cb)
 
-        self.batch_btn = QPushButton("Batch Caption All")
+        self.batch_btn = QPushButton("⚡  Batch Caption All")
         self.batch_btn.setProperty("class", "accent-button")
         self.batch_btn.setFixedHeight(40)
         self.batch_btn.setCursor(Qt.CursorShape.PointingHandCursor)
@@ -958,6 +967,14 @@ class SettingsPanel(QFrame):
         btn.style().unpolish(btn)
         btn.style().polish(btn)
 
+        # Remember the user's own prefix/suffix the first time we enter preset
+        # mode (old_id is None), so deselecting the preset restores them rather
+        # than leaving the preset's tokens applied. Switching preset→preset must
+        # not overwrite the stash with the outgoing preset's values.
+        if old_id is None:
+            self._user_prefix_before_preset = self.prefix_input.text()
+            self._user_suffix_before_preset = self.suffix_input.text()
+
         # Apply prefix, suffix
         self.prefix_input.setText(preset["prefix"])
         self.suffix_input.setText(preset["suffix"])
@@ -1025,6 +1042,13 @@ class SettingsPanel(QFrame):
         if prev_selection in _ALL_LENGTH_KEYS:
             self.caption_length_combo.setCurrentText(prev_selection)
         self.caption_length_combo.blockSignals(False)
+
+        # Restore the user's pre-preset prefix/suffix (cleared if they had
+        # none), so a toggled-off preset doesn't leave its tokens applied.
+        self.prefix_input.setText(self._user_prefix_before_preset or "")
+        self.suffix_input.setText(self._user_suffix_before_preset or "")
+        self._user_prefix_before_preset = None
+        self._user_suffix_before_preset = None
 
         # Restore editable prompt
         self.prompt_text.setReadOnly(False)

--- a/gui/version.py
+++ b/gui/version.py
@@ -1,6 +1,6 @@
 """Single source of truth for the application version."""
 
-APP_VERSION = "1.4.1"
+APP_VERSION = "1.4.3"
 
 # GitHub repo used by the in-app update check (Settings -> Check for Updates)
 GITHUB_REPO = "GitDonkeyHubbed/qwen3vl-captioner"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwen3vl-captioner"
-version = "1.4.1"
+version = "1.4.3"
 description = "Portable Qwen3-VL image captioning GUI with GGUF inference"
 requires-python = ">=3.11,<3.13"
 dependencies = [
@@ -16,7 +16,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # MLX backend for Apple Silicon Macs (installed automatically by setup.sh)
-mlx = ["mlx-vlm>=0.1.0"]
+mlx = ["mlx-vlm>=0.6"]
 
 [project.scripts]
 qwen3vl-captioner = "app:main"

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -63,6 +63,15 @@ def test_find_mmproj_file_locates_mmproj(tmp_path):
     assert "mmproj" in found.name.lower()
 
 
+def test_find_mmproj_file_prefers_f16(tmp_path):
+    """With several encoders present, the f16 mmproj is chosen deterministically
+    (not whatever iterdir() happens to yield first)."""
+    (tmp_path / "model.mmproj-Q8_0.gguf").write_bytes(b"\x00")
+    f16 = tmp_path / "model.mmproj-f16.gguf"
+    f16.write_bytes(b"\x00")
+    assert find_mmproj_file(tmp_path) == f16
+
+
 def test_find_mmproj_file_none_when_absent(tmp_path):
     (tmp_path / "model.Q4_K_M.gguf").write_bytes(b"\x00")
     assert find_mmproj_file(tmp_path) is None


### PR DESCRIPTION
## What this is

A full repository health check turned into fixes. Main is healthy — CI is green, no open issues/PRs, deps have no known CVEs, 92 tests pass — but a multi-agent audit surfaced **29 confirmed findings** (1 false positive rejected). This PR fixes all of the high/medium/low ones plus a few cheap nits. Every change keeps the CI mirror green (`compileall` / `pyflakes` / 92 pytest).

Findings were each adversarially verified against the source before fixing.

## Highlights

**🔴 High**
- **In-app version was stuck at 1.4.1** while the released tag/docs were 1.4.2, so *every up-to-date user* got a phantom "update available" popup. Versions are synced (now `1.4.3`, since this PR adds fixes — see note below).
- **GUI froze during a vision-encoder download.** When a model's `mmproj` was missing, the Load flow downloaded it synchronously on the Qt UI thread — window goes *Not Responding*, no progress, no cancel, for a multi-hundred-MB transfer. Now runs off-thread behind a responsive modal dialog.
- **Close-during-download crash risk.** `closeEvent` discarded the download thread's `wait()` result, so a thread stuck mid-shard could be destroyed while still running. Now honored like the other threads.

**🟠 Medium**
- Download integrity: a stale `.part` left under the same name by a different file could be silently appended onto and finalized as a **corrupt model** — now validated against an identity sidecar before resume.
- Deselecting a preset left its prefix/suffix (e.g. Pony's `score_9, …` / `, rating_safe`) baked into the input fields — now restores the user's own values.
- `diagnose.bat` read `%ERRORLEVEL%` without delayed expansion (stale parse-time value).
- Disk-space pre-flight before multi-GB downloads.

**🟡 Low / nits**
- Atomic `config.json` writes (no more truncation-on-crash losing settings).
- Non-streaming caption crash on `null` content; empty-`choices` guard.
- Deterministic `find_mmproj_file` (prefers `f16`).
- `mlx-vlm` extra floor raised to `>=0.6`; stray `.gitignore` lines removed; `Refer-as name` now emits `settings_changed`; batch-button label consistency; doc corrections (MLX lineup, "default quant" wording, project tree, CONTRIBUTING test reference).

## Version note (please confirm)

The audit's literal recommendation was to bump the code to **1.4.2** to match the released tag. Since this PR adds a batch of *new* fixes on top, I labeled it **1.4.3 (Unreleased)** instead — redefining the already-tagged 1.4.2 would be poor practice. With code at 1.4.3 and the latest release tag at V1.4.2, the update check correctly shows "up to date." If you'd rather fold these into 1.4.2, say so and I'll re-label.

## Known limitation (not fixed here)

Cancelling an **MLX folder (snapshot)** download still only takes effect *between* files — a large shard already in flight must finish first (`hf_hub_download` is uninterruptible per-file). The UI now says so instead of looking hung; a true streaming-with-cancel rewrite was out of scope for this pass.

## Test plan

- ✅ `python -m compileall app.py doctor.py engine gui tests`
- ✅ `pyflakes app.py doctor.py engine/*.py gui/*.py tests/*.py`
- ✅ `pytest tests/ -q` → 92 passed
- ✅ `pip-audit -r requirements.txt` → no known vulnerabilities
- ⚠️ Headless GUI import couldn't run in the dev sandbox (no `libEGL.so.1`); the Lint/Test and Windows Smoke CI jobs (which install Qt libs) will validate it.

The two GUI-threading changes (`main_window.py`) aren't covered by the unit suite — worth a careful look. Everything else is mechanical and low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gKBrKPmcYgQKp9oi1b2di

---
_Generated by [Claude Code](https://claude.ai/code/session_019gKBrKPmcYgQKp9oi1b2di)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Maintenance Release**
  * Added **1.4.3 (Unreleased)** and updated the app version display.
* **Bug Fixes**
  * Reduced UI freezes during vision-encoder downloads; improved resume/integrity checks (including partial downloads) and disk-space preflight.
  * Strengthened download shutdown/cancellation behavior and caption generation handling.
  * Made settings/config saving atomic and prevented closing if saving fails; restored preset prefix/suffix and refreshed “refer-as name”.
  * Improved model selection consistency and caption status coloring.
* **Documentation**
  * Updated README/CONTRIBUTING and added “What’s New in V1.4.3 — Health-Check Fixes”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->