### PR TITLE
Deep QC audit: fix caption-corruption race, EXIF rotation, 45 more verified findings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -23,8 +26,10 @@ jobs:
         run: python -m compileall -q app.py doctor.py engine gui tests
 
       - name: Pyflakes (undefined names, unused imports)
+        # requirements-dev.txt is the single source of dev-tool floors — CI
+        # must consume it or its pins are decorative and drift silently.
         run: |
-          pip install --quiet pyflakes
+          pip install --quiet -r requirements-dev.txt
           pyflakes app.py doctor.py engine/*.py gui/*.py tests/*.py
 
   test:
@@ -42,9 +47,53 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libegl1 libgl1
 
       - name: Install test dependencies
-        run: pip install --quiet pytest "PyQt6>=6.7"
+        run: pip install --quiet -r requirements-dev.txt "PyQt6>=6.7" "Pillow>=12.2.0"
 
       - name: Run pytest (core logic, headless)
         env:
           QT_QPA_PLATFORM: offscreen
         run: python -m pytest tests/ -q
+
+  wheel-urls:
+    # The llama-cpp fork wheels are pinned by release-tag URL in setup.bat.
+    # Release assets can be re-tagged or deleted; a rotted URL would only
+    # surface as a broken install on a user's machine. HEAD-check every CUDA
+    # tag here so it fails CI instead. setup.bat's WHEEL_URL template is the
+    # single source; the smoke workflow parses the same line.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: HEAD-check all pinned wheel URLs
+        run: |
+          python - <<'EOF'
+          import re, sys, urllib.request
+
+          template = None
+          for line in open("setup.bat", encoding="utf-8", errors="replace"):
+              m = re.search(r'set "WHEEL_URL=(https://[^"]+)"', line)
+              if m:
+                  template = m.group(1)
+                  break
+          assert template, "WHEEL_URL template not found in setup.bat"
+
+          sys.path.insert(0, ".")
+          from engine.cuda_setup import _WHEEL_TAGS
+
+          failures = []
+          for _, tag in _WHEEL_TAGS:
+              url = template.replace("!CUDA_WHEEL!", tag).replace("%%2B", "%2B")
+              req = urllib.request.Request(url, method="HEAD")
+              try:
+                  with urllib.request.urlopen(req, timeout=30) as resp:
+                      print(f"OK   {tag}: {resp.status}")
+              except Exception as exc:
+                  failures.append(tag)
+                  print(f"FAIL {tag}: {exc}\n     {url}")
+          if failures:
+              sys.exit(f"wheel URL(s) no longer published: {', '.join(failures)}")
+          EOF

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:
@@ -36,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:
@@ -63,6 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:
@@ -71,7 +77,7 @@ jobs:
       - name: HEAD-check all pinned wheel URLs
         run: |
           python - <<'EOF'
-          import re, sys, urllib.request
+          import re, sys, time, urllib.request
 
           template = None
           for line in open("setup.bat", encoding="utf-8", errors="replace"):
@@ -87,13 +93,21 @@ jobs:
           failures = []
           for _, tag in _WHEEL_TAGS:
               url = template.replace("!CUDA_WHEEL!", tag).replace("%%2B", "%2B")
-              req = urllib.request.Request(url, method="HEAD")
-              try:
-                  with urllib.request.urlopen(req, timeout=30) as resp:
-                      print(f"OK   {tag}: {resp.status}")
-              except Exception as exc:
+              # Retry with backoff so a transient network hiccup / rate limit
+              # doesn't fail CI when the URL hasn't actually rotted.
+              last_exc = None
+              for attempt in range(3):
+                  req = urllib.request.Request(url, method="HEAD")
+                  try:
+                      with urllib.request.urlopen(req, timeout=30) as resp:
+                          print(f"OK   {tag}: {resp.status}")
+                          break
+                  except Exception as exc:
+                      last_exc = exc
+                      time.sleep(5 * (attempt + 1))
+              else:
                   failures.append(tag)
-                  print(f"FAIL {tag}: {exc}\n     {url}")
+                  print(f"FAIL {tag}: {last_exc}\n     {url}")
           if failures:
               sys.exit(f"wheel URL(s) no longer published: {', '.join(failures)}")
           EOF

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     runs-on: windows-latest
@@ -31,23 +34,30 @@ jobs:
       - name: Install dependencies (same set as setup.bat)
         run: pip install -r requirements.txt
 
-      - name: Install llama-cpp-python wheel (cu124, as setup.bat would)
-        run: pip install "https://github.com/JamePeng/llama-cpp-python/releases/download/v0.3.40-cu124-win-20260608/llama_cpp_python-0.3.40%2Bcu124-cp312-cp312-win_amd64.whl"
+      - name: Install llama-cpp-python wheel (cu124, parsed from setup.bat)
+        # Single-source the wheel URL from setup.bat's WHEEL_URL template so
+        # this step can't silently drift from what setup.bat actually installs.
+        run: |
+          $line = Select-String -Path setup.bat -Pattern 'set "WHEEL_URL=(https://[^"]+)"' | Select-Object -First 1
+          if (-not $line) { throw "WHEEL_URL template not found in setup.bat" }
+          $url = $line.Matches[0].Groups[1].Value -replace '!CUDA_WHEEL!','cu124' -replace '%%2B','%2B'
+          echo "Installing $url"
+          pip install $url
 
       - name: Diagnostics report sanity (llama installed, no toolkit found)
         run: python -c "from engine.cuda_setup import diagnose; r = diagnose(); print(r); assert r['llama_cpp_installed'], 'wheel not detected'; assert r['toolkit_version'] is None, 'phantom toolkit found'"
 
       - name: Doctor report (informational — runner has no GPU, problems expected)
-        # doctor.py exits non-zero when it finds problems (always true on a
-        # GPU-less CI runner). In PowerShell, `|| echo ...` still leaves
-        # LASTEXITCODE set, so we explicitly normalize this informational
-        # non-zero exit to success for the workflow.
+        # doctor.py exit codes: 0 = healthy, 1 = problems found (always true
+        # on a GPU-less CI runner — informational, normalize to success),
+        # 2 = doctor itself crashed (a real bug — fail the workflow).
         run: |
           python doctor.py
-          if ($LASTEXITCODE -ne 0) {
+          if ($LASTEXITCODE -eq 1) {
             echo "(doctor reported issues — expected on a GPU-less runner)"
             exit 0
           }
+          exit $LASTEXITCODE
 
       - name: Headless app import (exercises the no-CUDA startup path)
         env:

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,76 @@ git tags (`V1.x.x`).
 
 ## [1.4.3] — Unreleased
 
-Maintenance release from a full repository health check (every finding
-adversarially verified against the source). No new features.
+Maintenance release from a full repository health check, followed by a second
+deep QC audit of the entire codebase (56 findings, each adversarially
+verified against the source — several reproduced empirically against live
+PyQt6 before fixing).
+
+### Fixed (QC audit round 2)
+- **Caption/save misattribution race (data corruption).** A finished caption
+  was cached and auto-saved under whatever image was *selected at completion
+  time*, not the image it was generated for — clicking thumbnail B while A's
+  caption streamed silently overwrote `B.txt` with A's caption. Results are
+  now pinned to the generating worker's own image, and batch items generate
+  the popped queue entry even if the selection changes mid-run.
+- **Sideways captions for phone photos.** The GGUF path never applied the
+  EXIF Orientation tag, so rotated camera JPEGs were captioned as a sideways
+  scene — invisibly, because the Qt preview auto-rotates. Orientation is now
+  applied before encoding; extreme aspect ratios also no longer crash resize
+  with a zero dimension (which aborted the rest of a batch).
+- **Saved theme ignored at startup.** The app always launched dark; the
+  persisted light-mode choice now applies on launch, translucent surfaces got
+  light-theme palette entries (they were hardcoded dark rgba), invalid QSS
+  (`::placeholder`, `letter-spacing`, `text-transform`, `line-height`) was
+  removed, and placeholder text is colored via `QPalette` as Qt requires.
+- **Resume regression from 1.4.3's own sidecar check.** Valid `.part` files
+  from pre-1.4.3 versions (which never had a `.meta` sidecar) were silently
+  discarded — multi-GB downloads restarted from zero on upgrade. Legacy
+  partials are now grandfathered via the old size heuristic and stamped with
+  a sidecar; the HTTP 416 finalize path also falls back to the sidecar's
+  recorded size when the live probe fails, instead of dead-ending.
+- **"Uncancellable" encoder dialog was dismissible with Esc**, silently
+  dropping application modality while the nested event loop still ran. The
+  dialog now genuinely ignores Esc/close until the download finishes.
+- **CUDA 13.x DLL preload was a silent no-op** (only the first `bin` dir was
+  globbed; CUDA 13 keeps its DLLs in `bin\x64`), and `doctor.py` reported a
+  false "[OK] Wheel/CUDA match" for toolkits older than 12.4. Doctor also no
+  longer fails a healthy Mac over the *optional* MLX backend, and exits 2 on
+  an internal crash (CI normalizes only exit 1).
+- **Batch state machine hardening.** Unload is refused during the between-item
+  gap (previously stranded a zombie batch), batch start is re-entrancy-guarded,
+  the batch button no longer re-enables while the last item is in flight,
+  "Clear all" cancels an in-flight generation instead of orphaning it, and the
+  stop-download confirm can no longer cancel a different (chained) download.
+- **hf_token hardening.** `~/.vlcaptioner/` is created `0700` and config.json
+  written `0600`; the download token is now also stripped on same-host
+  HTTPS→HTTP redirect downgrades; the update-check result is HTML-escaped
+  before rendering in a link-enabled label.
+- `pip install .` was broken (setuptools flat-layout refusal) — explicit
+  package discovery added, so the `qwen3vl-captioner` console script installs.
+- Snapshot downloads reject path-traversal filenames (defense-in-depth); the
+  status-bar RAM readout refreshes on the timer instead of only at startup.
+
+### Added (QC audit round 2)
+- **Download speed + ETA** in every download progress message, and a
+  time-remaining estimate in the batch queue label.
+- **Keyboard shortcuts**: Ctrl+S save caption, Ctrl+G generate,
+  Ctrl+←/→ (and PgUp/PgDn) previous/next image.
+- **Drag & drop anywhere** on the window (was: only the file-browser strip).
+- "Model not downloaded" dialog now offers to download the selected registry
+  model directly; the maximize button in the viewer toolbar actually works;
+  import dialogs remember the last-used folder; model-load errors show the
+  message with the traceback tucked into expandable details; a warning is
+  raised when images share a stem (they'd share one `.txt` caption).
+- **20 new tests** (113 total): EXIF/aspect-ratio image prep, `.part`
+  identity-sidecar contract, config save-failure surfacing, last-import-dir,
+  and a real truth-table for `mlx_backend_supported` (the old test re-derived
+  the production expression as its own oracle).
+- **CI hardening**: workflows get least-privilege `permissions` blocks; the
+  Windows smoke test parses the wheel URL from `setup.bat` (single source)
+  and a new job HEAD-checks all five pinned CUDA wheel URLs so a deleted
+  release fails CI instead of user installs; `requirements-dev.txt` is now
+  actually consumed by CI; the `uv` bootstrap installers are version-pinned.
 
 ### Fixed
 - **Version string lag.** `gui/version.py` and `pyproject.toml` were still

--- a/README.md
+++ b/README.md
@@ -41,15 +41,18 @@
 
 ---
 
-## 🩺 What's New in V1.4.3 — Health-Check Fixes
+## 🩺 What's New in V1.4.3 — Health-Check & Deep-QC Fixes
 
-No new features — a sweep of bug and consistency fixes from a full repository health check.
+No new models — two full audit passes over the codebase (85 verified findings fixed in total), plus quality-of-life upgrades.
 
-- **No more phantom "update available" popup** — the in-app version was stuck at 1.4.1 and now matches the build.
-- **The window no longer freezes** while downloading a model's vision encoder — it runs in the background behind a progress dialog instead of going *Not Responding*.
-- **Safer downloads & settings** — an interrupted download can no longer be finalized as a corrupt model, downloads check free disk space first, and `config.json` is written atomically so a crash can't wipe your token/settings.
-- **Preset fix** — turning a preset off now restores *your* prefix/suffix instead of leaving the preset's tags applied.
-- Plus smaller robustness fixes (caption edge cases, deterministic encoder pick, a `diagnose.bat` bug, and doc corrections).
+- **Your captions can no longer cross-save.** Clicking another image while a caption was generating could silently overwrite that image's `.txt` with the wrong caption — fixed at the root.
+- **Phone photos caption correctly now.** EXIF rotation is applied before inference, so sideways camera JPEGs no longer produce captions describing a rotated scene.
+- **No more phantom "update available" popup**, no more window freeze during vision-encoder downloads, and your saved **light/dark theme actually applies at startup**.
+- **Downloads got smarter**: live **speed + ETA**, free-disk-space pre-flight, corruption-proof resume (including partials from older versions), and your HF token is stored `0600` and never sent over plain HTTP.
+- **Faster & smoother**: thumbnails decode at thumbnail size (no more UI stalls on big imports), **keyboard shortcuts** (Ctrl+S save, Ctrl+G generate, Ctrl+←/→ navigate), **drag & drop anywhere**, batch ETA, and a download offer right in the "model not downloaded" dialog.
+- Test suite grew to **113 tests**; CI now HEAD-checks the pinned wheel URLs so a deleted release breaks CI, not your install.
+
+See [CHANGELOG.md](CHANGELOG.md) for the complete list.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -57,8 +57,16 @@ def main():
     app.setApplicationVersion(APP_VERSION)
     app.setOrganizationName("Qwen3VL-Captioner")
 
-    # Apply dark theme
-    app.setStyleSheet(get_stylesheet())
+    # Apply the SAVED theme (the stylesheet default is dark, so without this
+    # a user's persisted light-mode choice was ignored on every launch)
+    from gui.config import get_theme
+    from gui.theme import set_theme, apply_placeholder_palette
+    theme_mode = get_theme()
+    set_theme(theme_mode)
+    app.setStyleSheet(get_stylesheet(theme_mode))
+    # Placeholder color must go through the palette — Qt Style Sheets have no
+    # ::placeholder sub-control (the old QSS rule was silently ignored).
+    apply_placeholder_palette(app)
 
     # Set default font
     font = QFont("Segoe UI", 10)

--- a/doctor.py
+++ b/doctor.py
@@ -51,7 +51,14 @@ def _windows_checks(report: dict, problems: list):
             "Install/update the NVIDIA GPU driver: https://www.nvidia.com/drivers"
         )
 
-    if report["toolkit_version"]:
+    if report["toolkit_version"] and report.get("toolkit_too_old"):
+        print(f"{FAIL} CUDA Toolkit:    v{report['toolkit_version']} is older than the minimum supported 12.4")
+        problems.append(
+            f"CUDA Toolkit v{report['toolkit_version']} is too old for the published "
+            "llama-cpp-python wheels (oldest build is cu124).\n"
+            "         Upgrade the toolkit:  winget install Nvidia.CUDA  — then re-run setup.bat"
+        )
+    elif report["toolkit_version"]:
         print(f"{OK} CUDA Toolkit:    v{report['toolkit_version']}  ({report['toolkit_path']})")
     else:
         print(f"{FAIL} CUDA Toolkit:    NOT FOUND (the GPU driver alone is not enough)")
@@ -65,7 +72,11 @@ def _windows_checks(report: dict, problems: list):
     wheel_tag = report["wheel_cuda_tag"]
     rec_tag = report["recommended_tag"]
     if wheel_tag:
-        if report["tags_match"] is False:
+        if report.get("toolkit_too_old"):
+            # tags_match compares against the cu124 fallback, which a too-old
+            # toolkit cannot run — an "OK match" here would be a lie.
+            print(f"{FAIL} Wheel/CUDA match: wheel '{wheel_tag}' cannot run on toolkit v{report['toolkit_version']} (needs 12.4+)")
+        elif report["tags_match"] is False:
             print(f"{FAIL} Wheel/CUDA match: wheel is '{wheel_tag}' but your toolkit needs '{rec_tag}'")
             problems.append(
                 f"Re-run setup.bat — it will replace the {wheel_tag} wheel with the {rec_tag} build"
@@ -94,11 +105,11 @@ def _macos_checks(report: dict, problems: list):
             mlx_ver = version("mlx-vlm")
             print(f"{OK} MLX backend:     mlx-vlm {mlx_ver} installed")
         except Exception:
+            # Optional backend — print the suggestion inline rather than
+            # appending to `problems`, so a healthy Metal-only setup doesn't
+            # exit 1 / print "PROBLEMS FOUND" over a missing optional extra.
             print(f"{WARN} MLX backend:     mlx-vlm not installed (optional — MLX models hidden)")
-            problems.append(
-                "Optional: install the MLX backend with ./setup.sh "
-                "(or: .venv/bin/pip install mlx-vlm)"
-            )
+            print(f"{INFO}                  to enable: ./setup.sh  (or: .venv/bin/pip install mlx-vlm)")
 
 
 def main() -> int:
@@ -136,4 +147,12 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    # Exit codes: 0 = healthy, 1 = problems found (expected on e.g. GPU-less
+    # CI runners), 2 = doctor itself crashed. CI normalizes only 1, so a
+    # genuine crash in the diagnostics still fails the workflow.
+    try:
+        sys.exit(main())
+    except Exception:
+        import traceback
+        traceback.print_exc()
+        sys.exit(2)

--- a/engine/base.py
+++ b/engine/base.py
@@ -10,7 +10,10 @@ The app supports two inference backends behind one duck-typed interface:
     Apple Silicon only. Models are folders of safetensors — no mmproj.
 
 Every engine implements:
-  load_model(model_path, mmproj_path=None, *, progress_callback=None)
+  load_model(model_path, mmproj_path, *, progress_callback=None)
+    (mmproj_path is REQUIRED by the GGUF engine — pairing a model with a
+    missing/mismatched vision encoder crashes llama.cpp natively — and is
+    accepted-but-ignored by the MLX engine, whose models embed the tower)
   caption_image(image_path, prompt, ..., stream_callback, cancel_check) -> str
   unload()
   get_model_info() -> dict

--- a/engine/cuda_setup.py
+++ b/engine/cuda_setup.py
@@ -145,11 +145,15 @@ def setup_cuda_dll_path() -> Optional[Path]:
     import ctypes
 
     bin_dirs: list[Path] = []
+    root_version: dict[Path, tuple[int, int]] = {}
     for root in _cuda_install_roots():
+        ver = parse_cuda_version(root.name) or _version_from_install(root) or (0, 0)
         for sub in ("bin", os.path.join("bin", "x64")):
             path = root / sub
             if path.is_dir():
-                bin_dirs.append(path.resolve())
+                resolved = path.resolve()
+                bin_dirs.append(resolved)
+                root_version[resolved] = ver
 
     for bin_dir in bin_dirs:
         try:
@@ -181,13 +185,19 @@ def setup_cuda_dll_path() -> Optional[Path]:
     # ALL collected bin dirs, not just the first: CUDA 13.x on Windows moved
     # cudart64/cublas64 into bin\x64, so globbing only the plain bin dir made
     # this preload a silent no-op for exactly the cu130+ installs it targets.
+    # Scan newest toolkit first (matching how the wheel is chosen) — the raw
+    # bin_dirs order puts CUDA_PATH first, which may be an OLDER install, and
+    # the per-name dedup must not let its DLLs win over a newer toolkit's.
+    preload_order = sorted(
+        bin_dirs, key=lambda d: root_version.get(d, (0, 0)), reverse=True
+    )
     preload_patterns = ("cudart64_*.dll", "cublas64_*.dll", "cublasLt64_*.dll")
     preloaded: set[str] = set()
-    for bin_dir in bin_dirs:
+    for bin_dir in preload_order:
         for pattern in preload_patterns:
             for dll_path in sorted(bin_dir.glob(pattern), reverse=True):
                 if dll_path.name.lower() in preloaded:
-                    continue  # same DLL name found in an earlier (newer) root
+                    continue  # same DLL name already loaded from a newer root
                 try:
                     ctypes.CDLL(str(dll_path), winmode=ctypes.RTLD_GLOBAL)
                     preloaded.add(dll_path.name.lower())

--- a/engine/cuda_setup.py
+++ b/engine/cuda_setup.py
@@ -34,6 +34,11 @@ _WHEEL_TAGS = [
 
 DEFAULT_WHEEL_TAG = "cu124"
 
+# Oldest toolkit any published wheel supports. A detected toolkit below this
+# floor still maps to DEFAULT_WHEEL_TAG (setup scripts parse that contract),
+# but diagnose()/doctor flag it as too old instead of reporting a false match.
+MIN_SUPPORTED_TOOLKIT = (12, 4)
+
 
 def parse_cuda_version(text: str) -> Optional[tuple[int, int]]:
     """Parse 'v12.4', '12.4', or 'v13.0' into a (major, minor) tuple."""
@@ -172,17 +177,24 @@ def setup_cuda_dll_path() -> Optional[Path]:
     if not bin_dirs:
         return None
 
-    # Preload runtime DLLs for whatever CUDA major version is present.
-    cuda_bin = bin_dirs[0]
+    # Preload runtime DLLs for whatever CUDA major version is present. Scan
+    # ALL collected bin dirs, not just the first: CUDA 13.x on Windows moved
+    # cudart64/cublas64 into bin\x64, so globbing only the plain bin dir made
+    # this preload a silent no-op for exactly the cu130+ installs it targets.
     preload_patterns = ("cudart64_*.dll", "cublas64_*.dll", "cublasLt64_*.dll")
-    for pattern in preload_patterns:
-        for dll_path in sorted(cuda_bin.glob(pattern), reverse=True):
-            try:
-                ctypes.CDLL(str(dll_path), winmode=ctypes.RTLD_GLOBAL)
-            except OSError:
-                pass
+    preloaded: set[str] = set()
+    for bin_dir in bin_dirs:
+        for pattern in preload_patterns:
+            for dll_path in sorted(bin_dir.glob(pattern), reverse=True):
+                if dll_path.name.lower() in preloaded:
+                    continue  # same DLL name found in an earlier (newer) root
+                try:
+                    ctypes.CDLL(str(dll_path), winmode=ctypes.RTLD_GLOBAL)
+                    preloaded.add(dll_path.name.lower())
+                except OSError:
+                    pass
 
-    return cuda_bin
+    return bin_dirs[0]
 
 
 def cuda_toolkit_missing_message() -> str:
@@ -238,8 +250,13 @@ def diagnose() -> dict:
         report["toolkit_version"] = f"{ver[0]}.{ver[1]}"
         report["toolkit_path"] = str(root)
         report["recommended_tag"] = recommended_wheel_tag(ver)
+        # A toolkit older than every published wheel floor falls through to
+        # the cu124 default, which such a toolkit cannot actually run — flag
+        # it so doctor.py reports a real failure instead of a false OK match.
+        report["toolkit_too_old"] = ver < MIN_SUPPORTED_TOOLKIT
     else:
         report["recommended_tag"] = DEFAULT_WHEEL_TAG
+        report["toolkit_too_old"] = False
 
     try:
         from importlib.metadata import version

--- a/engine/inference.py
+++ b/engine/inference.py
@@ -12,7 +12,7 @@ import time
 from pathlib import Path
 from typing import Callable, Optional
 
-from PIL import Image
+from PIL import Image, ImageOps
 
 
 from engine.base import DEFAULT_SYSTEM_PROMPT, apply_prefix_suffix, clean_caption
@@ -55,18 +55,24 @@ def image_to_data_uri(image_path: Path, max_dim: int = 1280) -> str:
         A data URI string like 'data:image/png;base64,...'
     """
     # Open inside a context manager so the source file handle is released
-    # deterministically — convert() forces the pixel load, so the detached
-    # RGB copy needs no further access to the file. (Prevents a descriptor
-    # leak / Windows file lock during batch runs.)
+    # deterministically — exif_transpose + convert() force the pixel load, so
+    # the detached RGB copy needs no further access to the file. (Prevents a
+    # descriptor leak / Windows file lock during batch runs.)
+    #
+    # exif_transpose applies the EXIF Orientation tag (3/6/8 — ubiquitous in
+    # phone/camera JPEGs). Without it the model receives sideways pixels and
+    # captions a rotated scene — invisibly, because the Qt preview applies
+    # orientation on its own.
     with Image.open(image_path) as src:
-        img = src.convert("RGB")
+        img = ImageOps.exif_transpose(src).convert("RGB")
 
-    # Resize if any dimension exceeds max_dim
+    # Resize if any dimension exceeds max_dim. Clamp to >=1 px so an extreme
+    # aspect ratio (e.g. 10000x1) can't scale a side to zero and crash resize.
     w, h = img.size
     if w > max_dim or h > max_dim:
         scale = max_dim / max(w, h)
-        new_w = int(w * scale)
-        new_h = int(h * scale)
+        new_w = max(1, int(w * scale))
+        new_h = max(1, int(h * scale))
         img = img.resize((new_w, new_h), Image.LANCZOS)
     
     # Convert to PNG bytes then base64
@@ -241,7 +247,7 @@ class Qwen3VLEngine:
                     break
                 
                 choices = chunk.get("choices") or [{}]
-                delta = choices[0].get("delta", {})
+                delta = (choices[0] or {}).get("delta") or {}
                 token_text = delta.get("content", "")
                 if token_text:
                     caption_parts.append(token_text)

--- a/engine/mlx_engine.py
+++ b/engine/mlx_engine.py
@@ -66,12 +66,12 @@ def _stream_with_sampling(
     """Invoke mlx-vlm's stream_generate across a breaking sampling-API change.
 
     mlx-vlm/mlx-lm dropped the ``temperature``/``top_p`` keyword arguments on
-    ``stream_generate`` in favour of a ``sampler`` callable, and the project
-    pins only ``mlx-vlm>=0.1.0`` (no upper bound) — so a fresh setup.sh install
-    pulls the newer API where the old kwargs raise ``TypeError`` on every
-    caption. Prefer the sampler path; if this build doesn't accept ``sampler``
-    (older 0.1.x), fall back to the legacy kwargs so captioning works on either
-    version.
+    ``stream_generate`` in favour of a ``sampler`` callable. The project's
+    ``mlx`` extra now pins ``mlx-vlm>=0.6`` (sampler API), but setup.sh
+    installs unpinned ``mlx-vlm`` and pre-existing environments may still
+    carry an older 0.1.x build. Prefer the sampler path; if this build doesn't
+    accept ``sampler``, fall back to the legacy kwargs so captioning works on
+    either version.
     """
     if make_sampler == "auto":
         make_sampler = _load_make_sampler()

--- a/gui/app_settings_dialog.py
+++ b/gui/app_settings_dialog.py
@@ -7,6 +7,8 @@ Provides:
   - Persistent storage via gui.config
 """
 
+import html
+
 from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
@@ -266,14 +268,17 @@ class AppSettingsDialog(QDialog):
                     False,
                 )
             elif parse(latest) > parse(APP_VERSION):
+                # html.escape: `latest` is remote-controlled text rendered in a
+                # rich-text label with external links enabled — never
+                # interpolate it unescaped.
                 self._update_check_done.emit(
-                    f"New version available: {latest} — "
+                    f"New version available: {html.escape(latest)} — "
                     f"<a href='https://github.com/{GITHUB_REPO}/releases'>open releases page</a>",
                     True,
                 )
             else:
                 self._update_check_done.emit(
-                    f"You're up to date (latest: {latest}).", False
+                    f"You're up to date (latest: {html.escape(latest)}).", False
                 )
         except Exception as e:
             self._update_check_done.emit(f"Update check failed: {e}", False)

--- a/gui/config.py
+++ b/gui/config.py
@@ -21,11 +21,20 @@ _DEFAULTS: Dict[str, Any] = {
     # When True, captions are written to .txt sidecars without the
     # per-image confirmation popup
     "auto_save_captions": False,
+    # Folder the import file/folder dialogs open in (last one used)
+    "last_import_dir": "",
 }
 
 
 def _ensure_dir():
+    # The config file can hold the user's HF token — keep the directory
+    # owner-only so other local users can't read it. (chmod covers dirs
+    # created by older versions with default permissions; no-op on Windows.)
     _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(_CONFIG_DIR, 0o700)
+    except OSError:
+        pass
 
 
 def load_config() -> Dict[str, Any]:
@@ -61,7 +70,9 @@ def save_config(cfg: Dict[str, Any]) -> bool:
     try:
         _ensure_dir()
         tmp = _CONFIG_FILE.with_suffix(".json.tmp")
-        with open(tmp, "w", encoding="utf-8") as f:
+        # Owner-only from the first byte — the file can contain the HF token.
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(cfg, f, indent=2)
         os.replace(tmp, _CONFIG_FILE)
         return True
@@ -95,6 +106,18 @@ def add_custom_model(path: str):
         models.remove(path)
     models.append(path)
     cfg["custom_models"] = models
+    save_config(cfg)
+
+
+def get_last_import_dir() -> str:
+    """Folder the import dialogs should open in (last one used, or '')."""
+    value = load_config().get("last_import_dir", "")
+    return value if isinstance(value, str) else ""
+
+
+def set_last_import_dir(path: str):
+    cfg = load_config()
+    cfg["last_import_dir"] = str(path)
     save_config(cfg)
 
 

--- a/gui/dataset_panel.py
+++ b/gui/dataset_panel.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import List
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QPixmap
+from PyQt6.QtGui import QImageReader
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
     QFrame, QTableWidget, QTableWidgetItem, QHeaderView, QAbstractItemView,
@@ -218,10 +218,12 @@ class DatasetPanel(QFrame):
 
     @staticmethod
     def _get_image_dims(path: Path) -> str:
+        # QImageReader.size() reads dimensions from the header only — no pixel
+        # decode. QPixmap(path) fully decoded every image just for this label.
         try:
-            px = QPixmap(str(path))
-            if not px.isNull():
-                return f"{px.width()} x {px.height()}"
+            sz = QImageReader(str(path)).size()
+            if sz.isValid():
+                return f"{sz.width()} x {sz.height()}"
         except Exception:
             pass
         return "--"

--- a/gui/file_browser.py
+++ b/gui/file_browser.py
@@ -16,7 +16,9 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtGui import QPixmap, QPainter, QColor, QPen, QDragEnterEvent, QDropEvent
+from PyQt6.QtGui import (
+    QPixmap, QPainter, QColor, QPen, QDragEnterEvent, QDropEvent, QImageReader,
+)
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
     QLineEdit, QScrollArea, QFrame, QFileDialog,
@@ -113,15 +115,24 @@ class ThumbnailItem(QFrame):
         layout.addLayout(text_layout, 1)
 
     def _load_thumbnail(self):
-        """Load and scale the thumbnail image."""
-        pixmap = QPixmap(str(self.image_path))
-        if not pixmap.isNull():
-            scaled = pixmap.scaled(
-                THUMB_SIZE, THUMB_SIZE,
-                Qt.AspectRatioMode.KeepAspectRatio,
-                Qt.TransformationMode.SmoothTransformation,
+        """Load and scale the thumbnail image.
+
+        Decode via QImageReader with a target size so the JPEG decoder
+        downscales DURING decode — QPixmap(path) decoded every image at full
+        resolution (a 40MP photo → ~160 MB of pixels) just to draw a 56px
+        thumbnail, freezing the UI thread on large imports.
+        """
+        reader = QImageReader(str(self.image_path))
+        reader.setAutoTransform(True)  # honor EXIF orientation like the viewer
+        size = reader.size()
+        if size.isValid():
+            scaled = size.scaled(
+                THUMB_SIZE, THUMB_SIZE, Qt.AspectRatioMode.KeepAspectRatio
             )
-            self.thumb_label.setPixmap(scaled)
+            reader.setScaledSize(scaled)
+        image = reader.read()
+        if not image.isNull():
+            self.thumb_label.setPixmap(QPixmap.fromImage(image))
         else:
             self.thumb_label.setText("?")
 
@@ -213,6 +224,7 @@ class FileBrowserPanel(QFrame):
 
     image_selected = pyqtSignal(Path)
     images_imported = pyqtSignal(list)  # list[Path]
+    stem_collision_detected = pyqtSignal(str)  # warning text for the user
     clear_requested = pyqtSignal()      # emitted when user clicks Clear All
 
     def __init__(self, parent=None):
@@ -296,7 +308,7 @@ class FileBrowserPanel(QFrame):
         # ── Action buttons ──
         btn_frame = QFrame()
         btn_frame.setStyleSheet(
-            f"background: rgba(24, 24, 27, 0.5); "
+            f"background: {COLORS['surface_translucent']}; "
             f"border-top: 1px solid {COLORS['border']};"
         )
         btn_layout = QVBoxLayout(btn_frame)
@@ -433,6 +445,22 @@ class FileBrowserPanel(QFrame):
 
         self.count_label.setText(str(len(self._items)))
 
+        # Warn about stem collisions: photo.jpg and photo.png share ONE
+        # photo.txt sidecar, so captioning both silently overwrites one
+        # caption with the other.
+        stems: dict = {}
+        for item in self._items.values():
+            p = item.image_path
+            stems.setdefault(str(p.with_suffix("")), []).append(p.name)
+        collisions = [names for names in stems.values() if len(names) > 1]
+        if collisions and new_paths:
+            example = " / ".join(sorted(collisions[0]))
+            self.stem_collision_detected.emit(
+                f"{len(collisions)} image(s) share a name with a different "
+                f"extension (e.g. {example}) — they will share ONE .txt "
+                "caption file, overwriting each other."
+            )
+
         if new_paths:
             self.images_imported.emit(new_paths)
 
@@ -482,21 +510,26 @@ class FileBrowserPanel(QFrame):
         self.image_selected.emit(path)
 
     def _on_import_clicked(self):
-        """Open file dialog to import images."""
+        """Open file dialog to import images (remembers the last-used folder)."""
+        from gui.config import get_last_import_dir, set_last_import_dir
         ext_filter = "Images (" + " ".join(f"*{ext}" for ext in IMAGE_EXTENSIONS) + ")"
         paths, _ = QFileDialog.getOpenFileNames(
-            self, "Import Images", "", ext_filter,
+            self, "Import Images", get_last_import_dir(), ext_filter,
         )
         if paths:
+            set_last_import_dir(str(Path(paths[0]).parent))
             self.add_images([Path(p) for p in paths])
 
     def _on_import_folder_clicked(self):
-        """Open folder dialog to import all images from a directory."""
+        """Open folder dialog to import all images from a directory
+        (remembers the last-used folder)."""
+        from gui.config import get_last_import_dir, set_last_import_dir
         dir_path = QFileDialog.getExistingDirectory(
-            self, "Select Image Folder", "",
+            self, "Select Image Folder", get_last_import_dir(),
             QFileDialog.Option.ShowDirsOnly,
         )
         if dir_path:
+            set_last_import_dir(dir_path)
             self.import_directory(Path(dir_path))
 
     def _on_clear_clicked(self):

--- a/gui/file_browser.py
+++ b/gui/file_browser.py
@@ -447,16 +447,22 @@ class FileBrowserPanel(QFrame):
 
         # Warn about stem collisions: photo.jpg and photo.png share ONE
         # photo.txt sidecar, so captioning both silently overwrites one
-        # caption with the other.
+        # caption with the other. Only groups a NEWLY added file participates
+        # in are reported — recomputing over everything would re-fire the same
+        # warning on every later, unrelated import.
         stems: dict = {}
         for item in self._items.values():
             p = item.image_path
             stems.setdefault(str(p.with_suffix("")), []).append(p.name)
-        collisions = [names for names in stems.values() if len(names) > 1]
-        if collisions and new_paths:
-            example = " / ".join(sorted(collisions[0]))
+        new_stems = {str(p.with_suffix("")) for p in new_paths}
+        relevant = [
+            names for stem, names in stems.items()
+            if len(names) > 1 and stem in new_stems
+        ]
+        if relevant:
+            example = " / ".join(sorted(relevant[0]))
             self.stem_collision_detected.emit(
-                f"{len(collisions)} image(s) share a name with a different "
+                f"{len(relevant)} image(s) share a name with a different "
                 f"extension (e.g. {example}) — they will share ONE .txt "
                 "caption file, overwriting each other."
             )

--- a/gui/image_viewer.py
+++ b/gui/image_viewer.py
@@ -188,11 +188,13 @@ class ImageViewer(QFrame):
         self.reset_btn.clicked.connect(self._reset_view)
         tb_layout.addWidget(self.reset_btn)
 
-        # Maximize button
+        # Maximize button \u2014 toggles the top-level window between maximized
+        # and normal (was previously an unconnected, dead control)
         self.maximize_btn = QPushButton("\u26F6")  # square with corners
         self.maximize_btn.setProperty("class", "icon-button")
         self.maximize_btn.setFixedSize(28, 28)
-        self.maximize_btn.setToolTip("Maximize")
+        self.maximize_btn.setToolTip("Maximize / restore the window")
+        self.maximize_btn.clicked.connect(self._toggle_window_maximized)
         tb_layout.addWidget(self.maximize_btn)
 
         layout.addWidget(toolbar)
@@ -308,6 +310,14 @@ class ImageViewer(QFrame):
     def _reset_view(self):
         """Reset to fit-to-view zoom level."""
         self._fit_to_view()
+
+    def _toggle_window_maximized(self):
+        """Toggle the top-level window between maximized and normal."""
+        win = self.window()
+        if win.isMaximized():
+            win.showNormal()
+        else:
+            win.showMaximized()
 
     def resizeEvent(self, event):
         """Re-fit image when the viewer is resized and keep overlay sized."""

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from PyQt6.QtCore import Qt, QThread, QEventLoop, pyqtSignal, QObject, QTimer
+from PyQt6.QtGui import QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
     QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
     QFrame, QSplitter, QStatusBar, QProgressBar, QApplication, QFileDialog,
@@ -83,6 +84,41 @@ class _BlockingDownloadWorker(QObject):
             self.error.emit(str(e))
             return
         self.finished.emit(result)
+
+
+class _UnclosableProgressDialog(QProgressDialog):
+    """A QProgressDialog that ignores Esc and the title-bar close button.
+
+    QProgressDialog hides itself on Esc/close even with no Cancel button,
+    which would silently drop application modality while the nested event
+    loop of _download_mmproj_blocking is still running (leaving an invisible,
+    unstoppable download and a fully interactive main window mid-load).
+    Closing is re-enabled via allow_close() once the worker has finished.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._allow_close = False
+
+    def allow_close(self):
+        self._allow_close = True
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key.Key_Escape and not self._allow_close:
+            event.ignore()
+            return
+        super().keyPressEvent(event)
+
+    def reject(self):
+        # Esc reaches the dialog as reject(); swallow it while the worker runs.
+        if self._allow_close:
+            super().reject()
+
+    def closeEvent(self, event):
+        if self._allow_close:
+            super().closeEvent(event)
+        else:
+            event.ignore()
 
 
 # --- Worker for background caption generation ---
@@ -178,6 +214,7 @@ class MainWindow(QMainWindow):
         self._batch_queue: List[Path] = []
         self._batch_index = 0
         self._batch_active = False  # True from batch start until completion/abort
+        self._batch_current_path: Optional[Path] = None  # item pinned for the deferred timer
         self._download_thread: Optional[QThread] = None
         self._download_worker = None  # ModelDownloadWorker (lazy import)
         self._finished_threads: List[QThread] = []  # keep refs until done
@@ -187,10 +224,11 @@ class MainWindow(QMainWindow):
         self._nvml_handle = None
         self._init_nvml()
 
-        # Periodic GPU refresh timer (5 seconds)
+        # Periodic GPU/RAM refresh timer (5 seconds)
         self._gpu_timer = QTimer(self)
         self._gpu_timer.setInterval(5000)
         self._gpu_timer.timeout.connect(self._update_gpu_info)
+        self._gpu_timer.timeout.connect(self._update_ram_info)
 
         # Notification system
         self._notification_store = NotificationStore(self)
@@ -201,6 +239,11 @@ class MainWindow(QMainWindow):
         self._build_main_layout()
         self._build_status_bar()
         self._connect_signals()
+        self._setup_shortcuts()
+
+        # Folders/images can be dropped anywhere on the window, not just on
+        # the narrow file-browser strip (events are delegated to it).
+        self.setAcceptDrops(True)
 
         # Kick off GPU monitoring immediately (don't wait for model load)
         self._update_gpu_info()
@@ -570,6 +613,9 @@ class MainWindow(QMainWindow):
         """Wire up all component signals."""
         # File browser -> display
         self._file_browser.image_selected.connect(self._on_image_selected)
+        self._file_browser.stem_collision_detected.connect(
+            lambda msg: self._notify(msg, "warning")
+        )
         self._file_browser.clear_requested.connect(self._on_clear_all)
 
         # Caption panel
@@ -600,6 +646,39 @@ class MainWindow(QMainWindow):
         # Notification badge updates
         self._notification_store.notification_added.connect(self._update_bell_badge)
 
+    def _setup_shortcuts(self):
+        """Keyboard shortcuts for the core loop: navigate, generate, save.
+
+        Navigation deliberately uses Ctrl+arrows / PageUp+PageDown rather than
+        bare arrows, which must keep working inside the caption text editor.
+        """
+        QShortcut(QKeySequence.StandardKey.Save, self, self._save_current_caption)
+        QShortcut(QKeySequence("Ctrl+G"), self, self._generate_caption)
+        QShortcut(QKeySequence("Ctrl+Right"), self, lambda: self._select_adjacent(1))
+        QShortcut(QKeySequence("Ctrl+Left"), self, lambda: self._select_adjacent(-1))
+        QShortcut(QKeySequence(Qt.Key.Key_PageDown), self, lambda: self._select_adjacent(1))
+        QShortcut(QKeySequence(Qt.Key.Key_PageUp), self, lambda: self._select_adjacent(-1))
+
+    def _select_adjacent(self, delta: int):
+        """Select the next/previous image in the file browser."""
+        paths = self._file_browser.get_all_paths()
+        if not paths:
+            return
+        try:
+            idx = paths.index(self._current_image) + delta
+        except ValueError:
+            idx = 0
+        idx = max(0, min(idx, len(paths) - 1))
+        self._file_browser.select_item(paths[idx])
+
+    # --- Window-level drag & drop (delegated to the file browser) ---
+
+    def dragEnterEvent(self, event):
+        self._file_browser.dragEnterEvent(event)
+
+    def dropEvent(self, event):
+        self._file_browser.dropEvent(event)
+
     # --- Image Selection ---
 
     def _on_image_selected(self, path: Path):
@@ -626,6 +705,11 @@ class MainWindow(QMainWindow):
 
     def _on_clear_all(self):
         """Reset the workspace — clear all images, captions, and viewer state."""
+        # Cancel an in-flight generation first, or an orphan worker keeps
+        # streaming tokens into the freshly cleared panel.
+        if self._caption_worker and self._is_generating:
+            self._caption_worker.cancel()
+
         # Cancel any in-progress batch
         self._batch_queue.clear()
         self._batch_index = 0
@@ -700,6 +784,22 @@ class MainWindow(QMainWindow):
         # Find the model file (GGUF) or folder (MLX)
         model_path = self._find_model_file()
         if not model_path:
+            # For a registry model we know exactly what to fetch — offer to
+            # download it right here instead of pointing at the ⬇ button.
+            kind, value = self._settings_panel.get_selected_model()
+            info = self._selected_registry_info()
+            if kind == "registry" and info:
+                answer = QMessageBox.question(
+                    self, "Model Not Downloaded",
+                    f"'{value}' isn't downloaded yet "
+                    f"(~{info.get('size_gb', 0):.1f} GB).\n\n"
+                    "Download it now?",
+                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                    QMessageBox.StandardButton.Yes,
+                )
+                if answer == QMessageBox.StandardButton.Yes:
+                    self._download_model(value)
+                return
             QMessageBox.warning(
                 self, "Model Not Found",
                 "Could not find the selected model on disk.\n\n"
@@ -763,7 +863,7 @@ class MainWindow(QMainWindow):
         worker = _BlockingDownloadWorker(fn)
         worker.moveToThread(thread)
 
-        dialog = QProgressDialog(
+        dialog = _UnclosableProgressDialog(
             f"{title}\nThis can take a while for large encoders…",
             None, 0, 0, self,   # no Cancel button; 0/0 = indeterminate
         )
@@ -798,6 +898,7 @@ class MainWindow(QMainWindow):
         thread.start()
         dialog.show()
         loop.exec()            # keeps the UI alive until the worker signals done
+        dialog.allow_close()
         dialog.close()
 
         thread.quit()
@@ -954,18 +1055,30 @@ class MainWindow(QMainWindow):
         self._settings_panel.load_model_btn.setEnabled(True)
         self._set_connection_status("error", "Error")
         self._notify(f"Model load failed: {error[:80]}", "error")
-        QMessageBox.critical(self, "Model Load Error", f"Failed to load model:\n\n{error}")
+        # Show the human-readable error up front; tuck the raw traceback into
+        # the expandable details instead of dumping it as the message body.
+        msg, _, tb = error.partition("\nTraceback")
+        box = QMessageBox(
+            QMessageBox.Icon.Critical, "Model Load Error",
+            f"Failed to load model:\n\n{msg.strip()[:600]}", parent=self,
+        )
+        if tb:
+            box.setDetailedText("Traceback" + tb)
+        box.exec()
 
     def _unload_model(self):
         """Unload the current model and reset UI state."""
         if not self._engine.is_loaded:
             return
 
-        # Don't unload while generating
-        if self._is_generating:
+        # Don't unload while generating — including the ~100 ms gap between
+        # batch items, where _is_generating is briefly False but the batch
+        # timer is about to fire on the unloaded engine (zombie batch).
+        if self._is_generating or self._batch_active or self._batch_queue:
             QMessageBox.warning(
                 self, "Cannot Unload",
-                "Please wait for the current generation to finish before unloading."
+                "Please wait for the current generation/batch to finish "
+                "(or cancel it) before unloading."
             )
             return
 
@@ -993,15 +1106,17 @@ class MainWindow(QMainWindow):
         dlg = AppSettingsDialog(self)
         dlg.theme_changed.connect(self._on_theme_changed)
         dlg.exec()
+        dlg.deleteLater()  # don't accumulate a dialog per gear click
 
     def _on_theme_changed(self, mode: str):
         """Handle theme switch from settings dialog."""
-        from gui.theme import set_theme, get_stylesheet
+        from gui.theme import set_theme, get_stylesheet, apply_placeholder_palette
         set_theme(mode)
         from PyQt6.QtWidgets import QApplication
         app_instance = QApplication.instance()
         if app_instance:
             app_instance.setStyleSheet(get_stylesheet(mode))
+            apply_placeholder_palette(app_instance)
 
     # --- Model Downloading ---
 
@@ -1185,6 +1300,12 @@ class MainWindow(QMainWindow):
             self._hide_download_stop_btn()
             return
 
+        # Capture the worker BEFORE the modal dialog: while it is open the
+        # event loop keeps running, so the download can finish and a chained
+        # one (e.g. the auto-mmproj) can start — cancelling the new worker
+        # because of a dialog answered about the old one would be wrong.
+        worker_at_prompt = self._download_worker
+
         answer = QMessageBox.question(
             self, "Stop Download",
             "Stop the current download and delete the partial file?\n\n"
@@ -1194,6 +1315,11 @@ class MainWindow(QMainWindow):
         )
         if answer != QMessageBox.StandardButton.Yes:
             return
+        if (
+            worker_at_prompt is not self._download_worker
+            or not (self._download_thread and self._download_thread.isRunning())
+        ):
+            return  # the download the user answered about is already gone
 
         # Don't auto-start the matching mmproj after the model is cancelled
         self._pending_mmproj = None
@@ -1398,13 +1524,20 @@ class MainWindow(QMainWindow):
 
     # --- Caption Generation ---
 
-    def _generate_caption(self):
-        """Generate caption for the current image."""
+    def _generate_caption(self, image_path: Optional[Path] = None):
+        """Generate a caption for *image_path* (default: the current image).
+
+        The target is pinned HERE, at start — everything downstream
+        (_on_caption_finished) attributes the result to the worker's own
+        image_path, never to whatever happens to be selected when the
+        caption completes.
+        """
+        target = image_path or self._current_image
         if not self._engine.is_loaded:
             QMessageBox.warning(self, "Model Required", "Please load the model first.")
             return
 
-        if not self._current_image:
+        if not target:
             QMessageBox.warning(self, "No Image", "Please select an image first.")
             return
 
@@ -1430,7 +1563,7 @@ class MainWindow(QMainWindow):
         self._generation_thread = QThread()
         self._caption_worker = CaptionWorker(
             engine=self._engine,
-            image_path=self._current_image,
+            image_path=target,
             prompt=self._settings_panel.get_prompt(),
             temperature=self._settings_panel.get_temperature(),
             top_p=self._settings_panel.get_top_p(),
@@ -1483,17 +1616,37 @@ class MainWindow(QMainWindow):
             self._caption_panel.show_feedback("Nothing to cancel", is_success=False)
 
     def _on_caption_finished(self, caption: str):
-        """Handle completed caption generation."""
+        """Handle completed caption generation.
+
+        CRITICAL: the result is attributed to the image the WORKER was started
+        for, not to self._current_image — the user may have clicked another
+        thumbnail while the caption streamed, and saving under the selection
+        would silently overwrite that other image's caption file.
+        """
+        worker_path = (
+            self._caption_worker.image_path if self._caption_worker
+            else self._current_image
+        )
+
         self._is_generating = False
         self._caption_panel.set_generating(False)
         self._settings_panel.set_generating(False)
         self._image_viewer.set_processing(False)
 
-        # Cache the caption
-        if self._current_image:
-            self._captions[str(self._current_image)] = caption
-            self._file_browser.set_item_caption(self._current_image, caption)
-            self._file_browser.set_item_status(self._current_image, "done")
+        # Cache the caption under the image it belongs to
+        if worker_path:
+            self._captions[str(worker_path)] = caption
+            self._file_browser.set_item_caption(worker_path, caption)
+            self._file_browser.set_item_status(worker_path, "done")
+
+        # If the selection moved mid-generation, the panel holds the streamed
+        # text of ANOTHER image — restore the selected image's own caption.
+        if worker_path != self._current_image and self._current_image:
+            own = self._captions.get(str(self._current_image))
+            if own:
+                self._caption_panel.set_caption(own)
+            else:
+                self._caption_panel.clear_caption()
 
         # Update inference time
         inf_time = self._engine.last_inference_time
@@ -1508,20 +1661,20 @@ class MainWindow(QMainWindow):
         # caption is in flight. Using the flag ensures the last item is saved
         # silently like the rest and that _on_batch_complete still runs.
         if self._batch_active:
-            self._auto_save_caption(self._current_image, caption)
+            self._auto_save_caption(worker_path, caption)
             self._process_next_batch_item()
         elif self._settings_panel.get_auto_save():
-            self._auto_save_caption(self._current_image, caption)
+            self._auto_save_caption(worker_path, caption)
         else:
             # Single image: ask the user
-            self._prompt_auto_save(caption)
+            self._prompt_auto_save(worker_path, caption)
 
-    def _prompt_auto_save(self, caption: str):
+    def _prompt_auto_save(self, image_path: Optional[Path], caption: str):
         """Show a Yes/No dialog asking whether to auto-save the caption file."""
-        if not self._current_image or not caption:
+        if not image_path or not caption:
             return
 
-        txt_path = self._current_image.with_suffix(".txt")
+        txt_path = image_path.with_suffix(".txt")
         answer = QMessageBox.question(
             self, "Auto Save Caption",
             f"Caption generated!\n\n"
@@ -1532,7 +1685,7 @@ class MainWindow(QMainWindow):
             QMessageBox.StandardButton.Yes,  # default to Yes
         )
         if answer == QMessageBox.StandardButton.Yes:
-            self._auto_save_caption(self._current_image, caption)
+            self._auto_save_caption(image_path, caption)
 
     def _auto_save_caption(self, image_path: Path, caption: str):
         """Silently save a caption as a .txt sidecar file."""
@@ -1608,6 +1761,9 @@ class MainWindow(QMainWindow):
 
     def _batch_caption_all(self):
         """Start batch captioning for all imported images."""
+        if self._batch_active or self._is_generating:
+            return  # re-entrancy guard: a batch or single caption is running
+
         if not self._engine.is_loaded:
             QMessageBox.warning(self, "Model Required", "Please load the model first.")
             return
@@ -1617,6 +1773,7 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(self, "No Images", "Please import images first.")
             return
 
+        self._batch_current_path: Optional[Path] = None
         self._batch_queue = list(all_paths)
         self._batch_index = 0
         self._batch_active = True
@@ -1640,6 +1797,10 @@ class MainWindow(QMainWindow):
 
         path = self._batch_queue.pop(0)
         self._batch_index += 1
+        # Pin the batch target: generation must run on the POPPED item, not on
+        # whatever the selection happens to be when the deferred timer fires —
+        # a user click in the 100 ms gap would otherwise redirect the batch.
+        self._batch_current_path = path
 
         # Update UI
         self._file_browser.set_item_status(path, "processing")
@@ -1648,7 +1809,17 @@ class MainWindow(QMainWindow):
             self._batch_index, self._batch_index + len(self._batch_queue)
         )
         self._progress_bar.setValue(self._batch_index)
-        self._queue_label.setText(f"Queue: {len(self._batch_queue)} remaining")
+        eta_txt = ""
+        inf_t = getattr(self._engine, "last_inference_time", 0) or 0
+        if inf_t > 0:
+            eta_s = (len(self._batch_queue) + 1) * inf_t
+            eta_txt = (
+                f" (~{eta_s:.0f}s left)" if eta_s < 90
+                else f" (~{eta_s / 60:.0f} min left)"
+            )
+        self._queue_label.setText(
+            f"Queue: {len(self._batch_queue)} remaining{eta_txt}"
+        )
 
         # Generate (will call _process_next_batch_item on finish via _on_caption_finished)
         QTimer.singleShot(100, self._start_deferred_batch_caption)
@@ -1662,7 +1833,7 @@ class MainWindow(QMainWindow):
         generation on the last-selected image after cancellation.
         """
         if self._batch_active:
-            self._generate_caption()
+            self._generate_caption(self._batch_current_path)
 
     def _on_batch_complete(self):
         """Handle batch completion."""
@@ -1671,21 +1842,19 @@ class MainWindow(QMainWindow):
         self._batch_index = 0
         self._progress_bar.setVisible(False)
         self._queue_label.setText(f"Batch complete: {total} images captioned")
-        self._settings_panel.set_batch_progress(total, total)
+        # (0, 0) resets the batch button — only now, with no item in flight
+        self._settings_panel.set_batch_progress(0, 0)
         self._caption_panel.show_feedback(f"Batch complete! {total} images captioned.")
         self._notify(f"Batch complete: {total} images captioned", "success")
 
-        # Prompt to auto-save all batch captions
-        answer = QMessageBox.question(
-            self, "Auto Save All Captions",
-            f"Batch captioning complete! ({total} images)\n\n"
-            "All captions were saved during batch processing.\n"
-            "Would you also like to export all captions as .txt files?",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-            QMessageBox.StandardButton.No,
+        # Every caption was already written as a .txt sidecar during the run —
+        # a "would you also like to export .txt files?" question here was a
+        # confusing no-op, so just confirm what happened.
+        QMessageBox.information(
+            self, "Batch Complete",
+            f"Batch complete — {total} captions saved as .txt files "
+            "next to the images.",
         )
-        if answer == QMessageBox.StandardButton.Yes:
-            self._export_all_captions()
 
     # --- Save / Export ---
 

--- a/gui/model_download_manager.py
+++ b/gui/model_download_manager.py
@@ -17,7 +17,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Optional, Dict, Any, List
 
 from PyQt6.QtCore import QObject, pyqtSignal
@@ -366,8 +366,11 @@ class _StripAuthOnRedirect(urllib.request.HTTPRedirectHandler):
         new = super().redirect_request(req, fp, code, msg, headers, newurl)
         if new is not None:
             old_host = urllib.parse.urlparse(req.full_url).netloc
-            new_host = urllib.parse.urlparse(newurl).netloc
-            if old_host != new_host:
+            new_url = urllib.parse.urlparse(newurl)
+            # Strip the token on any cross-host hop, and also on a same-host
+            # https->http downgrade — a Bearer token must never travel in
+            # cleartext.
+            if old_host != new_url.netloc or new_url.scheme != "https":
                 new.headers.pop("Authorization", None)
         return new
 
@@ -376,8 +379,9 @@ class ModelDownloadWorker(QObject):
     """Downloads a single GGUF file from HuggingFace with streaming progress.
 
     Downloads to a .part file (resumable via HTTP Range) and renames it on
-    completion, so a cancelled or interrupted download picks up where it
-    left off the next time.
+    completion. An interrupted single-stream download resumes from its .part;
+    a user-cancelled download — and any interrupted parallel download, whose
+    offset-written .part cannot be trusted — discards its partial file.
 
     Signals
     -------
@@ -461,6 +465,11 @@ class ModelDownloadWorker(QObject):
                     _discard_partial()
                     self.error.emit("Download cancelled.")
                     return
+                # Defense-in-depth: never let a remote-listed filename escape
+                # the destination folder (absolute path or .. traversal).
+                fparts = PurePosixPath(fname)
+                if fparts.is_absolute() or ".." in fparts.parts:
+                    continue
                 self.progress.emit(
                     f"{self.snapshot_folder}/ — {fname} ({i + 1}/{n})",
                     i / n,
@@ -707,6 +716,7 @@ class ModelDownloadWorker(QObject):
         with concurrent.futures.ThreadPoolExecutor(max_workers=conns) as pool:
             futures = [pool.submit(fetch, s, e) for s, e in ranges]
             last_emit = 0.0
+            prev_t, prev_done = time.monotonic(), 0
             while any(not fut.done() for fut in futures):
                 now = time.monotonic()
                 if now - last_emit >= 0.5:
@@ -714,10 +724,12 @@ class ModelDownloadWorker(QObject):
                     with lock:
                         done = state["done"]
                     fraction = done / total if total else 0.0
+                    rate = self._rate_eta(done - prev_done, now - prev_t, total - done)
+                    prev_t, prev_done = now, done
                     self.progress.emit(
                         f"{self.filename} — {done / 1024**3:.2f} / "
                         f"{total / 1024**3:.2f} GB ({fraction * 100:.0f}%, "
-                        f"{conns} connections)",
+                        f"{conns} connections{rate})",
                         fraction,
                     )
                 time.sleep(0.1)
@@ -790,6 +802,32 @@ class ModelDownloadWorker(QObject):
             return False
         return True
 
+    def _recorded_part_total(self, part: Path) -> int:
+        """Total size recorded in the .part's identity sidecar (0 if unknown
+        or the sidecar belongs to a different repo/file)."""
+        try:
+            data = json.loads(
+                self._part_meta_path(part).read_text(encoding="utf-8")
+            )
+            if (data.get("repo_id") == self.repo_id
+                    and data.get("filename") == self.filename):
+                return int(data.get("total") or 0)
+        except Exception:
+            pass
+        return 0
+
+    @staticmethod
+    def _rate_eta(bytes_delta: float, secs: float, remaining: float) -> str:
+        """Format ', N MB/s, ~M min left' from a progress sample ('' if unknown)."""
+        if secs <= 0 or bytes_delta <= 0:
+            return ""
+        speed = bytes_delta / secs
+        text = f", {speed / 1024**2:.0f} MB/s"
+        if remaining > 0:
+            eta = remaining / speed
+            text += f", ~{eta:.0f}s left" if eta < 90 else f", ~{eta / 60:.0f} min left"
+        return text
+
     def _run_single(self, url, target: Path, part: Path):
         """Download *url* into *part* over a single resumable connection."""
         try:
@@ -801,16 +839,24 @@ class ModelDownloadWorker(QObject):
                 # alone can't prove a partial belongs to this file — a leftover
                 # .part from a *different* file under the same name that is
                 # SMALLER than the new remote file would otherwise be appended
-                # onto, producing a full-size but corrupt result. So discard the
-                # .part unless its identity sidecar matches this exact repo/file
-                # (and recorded size), or if it already exceeds the remote size.
+                # onto, producing a full-size but corrupt result.
                 # (A matching .part exactly == total is kept and the 416 branch
                 # below finalizes it.)
                 probed_total, _ = self._probe(url)
-                if (
-                    not self._part_identity_matches(part, probed_total)
-                    or (probed_total and resume_pos > probed_total)
-                ):
+                if self._part_meta_path(part).exists():
+                    # Sidecar present: it must name this exact repo/file.
+                    keep = self._part_identity_matches(part, probed_total)
+                else:
+                    # Pre-1.4.3 partial — the sidecar scheme didn't exist yet.
+                    # Grandfather it with the old size-only heuristic instead
+                    # of throwing away a multi-GB download on upgrade, and
+                    # stamp a sidecar so future resumes are fully verified.
+                    keep = True
+                if keep and probed_total and resume_pos > probed_total:
+                    keep = False  # larger than the remote file — cannot be ours
+                if keep and not self._part_meta_path(part).exists():
+                    self._write_part_identity(part, probed_total)
+                if not keep:
                     self._safe_unlink(part)
                     self._safe_unlink(self._part_meta_path(part))
                     resume_pos = 0
@@ -828,20 +874,24 @@ class ModelDownloadWorker(QObject):
             except urllib.error.HTTPError as http_err:
                 if http_err.code == 416 and resume_pos:
                     # 416 = requested range unsatisfiable. Only treat the .part
-                    # as complete when its size matches the known remote total —
-                    # a 416 alone doesn't prove completeness (the probe may have
-                    # failed, or the .part may be oversized/corrupt). When we
-                    # can't verify, keep the .part for a future resume rather
-                    # than promoting possibly-corrupt data to the final file.
-                    if probed_total and resume_pos == probed_total:
+                    # as complete when its size matches a known total — from
+                    # the live probe, or (when the probe failed) the total
+                    # recorded in the identity sidecar at download time.
+                    expected = probed_total or self._recorded_part_total(part)
+                    if expected and resume_pos == expected:
                         part.replace(target)
                         self._safe_unlink(self._part_meta_path(part))
                         self.progress.emit("Download complete", 1.0)
                         self.finished.emit(str(target))
                         return
+                    # Unverifiable (or sized beyond EOF): a retry would hit the
+                    # same 416 forever, so discard the partial to break the
+                    # dead-end and let the next attempt start fresh.
+                    self._safe_unlink(part)
+                    self._safe_unlink(self._part_meta_path(part))
                     self.error.emit(
-                        "Could not verify the existing partial download; "
-                        "download again to retry."
+                        "The existing partial download could not be verified "
+                        "and was removed — download again to start fresh."
                     )
                     return
                 raise
@@ -862,6 +912,7 @@ class ModelDownloadWorker(QObject):
 
                 downloaded = resume_pos
                 last_emit = 0.0
+                prev_t, prev_done = time.monotonic(), downloaded
                 self.target_dir.mkdir(parents=True, exist_ok=True)
 
                 if resume_pos == 0:
@@ -886,17 +937,22 @@ class ModelDownloadWorker(QObject):
                         now = time.monotonic()
                         if now - last_emit >= 0.5:
                             last_emit = now
+                            rate = self._rate_eta(
+                                downloaded - prev_done, now - prev_t,
+                                (total - downloaded) if total else 0,
+                            )
+                            prev_t, prev_done = now, downloaded
                             if total:
                                 fraction = downloaded / total
                                 self.progress.emit(
                                     f"{self.filename} — "
                                     f"{downloaded / 1024**3:.2f} / {total / 1024**3:.2f} GB "
-                                    f"({fraction * 100:.0f}%)",
+                                    f"({fraction * 100:.0f}%{rate})",
                                     fraction,
                                 )
                             else:
                                 self.progress.emit(
-                                    f"{self.filename} — {downloaded / 1024**3:.2f} GB...",
+                                    f"{self.filename} — {downloaded / 1024**3:.2f} GB...{rate}",
                                     0.0,
                                 )
 

--- a/gui/model_download_manager.py
+++ b/gui/model_download_manager.py
@@ -17,7 +17,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Optional, Dict, Any, List
 
 from PyQt6.QtCore import QObject, pyqtSignal
@@ -356,6 +356,24 @@ def mlx_model_exists(model_dir: Path, folder: str) -> bool:
 # Download worker
 # ---------------------------------------------------------------------------
 
+def is_unsafe_repo_filename(fname: str) -> bool:
+    """True if a remote-listed repo filename could escape the download dir.
+
+    Checked under BOTH path flavors: PurePosixPath alone would not treat
+    backslashes as separators, so on Windows ``..\\evil`` or ``C:\\...``
+    would slip through a POSIX-only guard.
+    """
+    posix = PurePosixPath(fname)
+    win = PureWindowsPath(fname)
+    return (
+        posix.is_absolute()
+        or win.is_absolute()
+        or bool(win.drive)          # covers drive-relative forms like C:evil
+        or ".." in posix.parts
+        or ".." in win.parts
+    )
+
+
 class _StripAuthOnRedirect(urllib.request.HTTPRedirectHandler):
     """Drop the Authorization header when HF redirects to its CDN.
 
@@ -466,9 +484,9 @@ class ModelDownloadWorker(QObject):
                     self.error.emit("Download cancelled.")
                     return
                 # Defense-in-depth: never let a remote-listed filename escape
-                # the destination folder (absolute path or .. traversal).
-                fparts = PurePosixPath(fname)
-                if fparts.is_absolute() or ".." in fparts.parts:
+                # the destination folder (absolute path, drive prefix, or
+                # .. traversal — in either POSIX or Windows form).
+                if is_unsafe_repo_filename(fname):
                     continue
                 self.progress.emit(
                     f"{self.snapshot_folder}/ — {fname} ({i + 1}/{n})",

--- a/gui/notification_panel.py
+++ b/gui/notification_panel.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import List
 
 from PyQt6.QtCore import Qt, pyqtSignal, QObject, QPoint
+from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import (
     QFrame, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
     QScrollArea, QWidget, QGraphicsDropShadowEffect,
@@ -169,12 +170,7 @@ class NotificationPanel(QFrame):
         shadow = QGraphicsDropShadowEffect(self)
         shadow.setBlurRadius(24)
         shadow.setOffset(0, 4)
-        shadow.setColor(COLORS["bg_darkest"] if isinstance(COLORS["bg_darkest"], type(shadow.color())) else shadow.color())
-        try:
-            from PyQt6.QtGui import QColor as _QC
-            shadow.setColor(_QC(0, 0, 0, 100))
-        except Exception:
-            pass
+        shadow.setColor(QColor(0, 0, 0, 100))
         self.setGraphicsEffect(shadow)
 
     # -- public --

--- a/gui/settings_panel.py
+++ b/gui/settings_panel.py
@@ -1386,8 +1386,13 @@ class SettingsPanel(QFrame):
         self.inference_time_label.setVisible(True)
 
     def set_batch_progress(self, current: int, total: int):
-        """Update batch button text with progress."""
-        if current < total:
+        """Update batch button text with progress.
+
+        (0, 0) resets the button; any total > 0 keeps it disabled — including
+        the final item, whose caption is still generating when current == total
+        (re-enabling there allowed a second batch to start mid-flight).
+        """
+        if total > 0:
             self.batch_btn.setText(f"  Processing {current}/{total}...")
             self.batch_btn.setEnabled(False)
         else:

--- a/gui/theme.py
+++ b/gui/theme.py
@@ -36,6 +36,10 @@ _DARK_COLORS: Dict[str, str] = {
     "text_secondary": "#a1a1aa",   # zinc-400
     "text_dim":       "#71717a",   # zinc-500
     "text_muted":     "#52525b",   # zinc-600
+    # Translucent surfaces (previously hardcoded dark rgba in the QSS, which
+    # made these panels near-unreadable in light mode)
+    "surface_translucent": "rgba(24, 24, 27, 0.5)",
+    "hover_translucent":   "rgba(39, 39, 42, 0.5)",
 
     # Accent — blue-600
     "accent":         "#2563eb",
@@ -84,6 +88,8 @@ _LIGHT_COLORS: Dict[str, str] = {
     "text_secondary": "#52525b",   # zinc-600
     "text_dim":       "#71717a",   # zinc-500
     "text_muted":     "#a1a1aa",   # zinc-400
+    "surface_translucent": "rgba(244, 244, 245, 0.6)",
+    "hover_translucent":   "rgba(228, 228, 231, 0.6)",
 
     # Accent — blue-600 (same)
     "accent":         "#2563eb",
@@ -126,6 +132,19 @@ def set_theme(mode: str = "dark"):
     COLORS.update(source)
 
 
+def apply_placeholder_palette(app):
+    """Set the input-placeholder text color via QPalette.
+
+    Qt Style Sheets have no ``::placeholder`` sub-control, so this is the only
+    supported way to color placeholder text. Call after set_theme()/
+    setStyleSheet() — at startup and on every theme switch.
+    """
+    from PyQt6.QtGui import QPalette, QColor
+    pal = app.palette()
+    pal.setColor(QPalette.ColorRole.PlaceholderText, QColor(COLORS["text_muted"]))
+    app.setPalette(pal)
+
+
 # ---------------------------------------------------------------------------
 # Stylesheet generator
 # ---------------------------------------------------------------------------
@@ -162,22 +181,17 @@ def get_stylesheet(mode: str = "dark") -> str:
         color: {c['text_dim']};
         font-size: 10px;
         font-weight: 700;
-        letter-spacing: 1.5px;
-        text-transform: uppercase;
         padding: 8px 0 4px 0;
     }}
     QLabel[class="brand-title"] {{
         color: {c['text_primary']};
         font-size: 13px;
         font-weight: 700;
-        letter-spacing: -0.3px;
     }}
     QLabel[class="brand-subtitle"] {{
         color: {c['text_dim']};
         font-size: 10px;
         font-family: 'Consolas', 'Courier New', monospace;
-        letter-spacing: -0.5px;
-        text-transform: uppercase;
     }}
     QLabel[class="version-label"] {{
         color: {c['text_dim']};
@@ -196,8 +210,6 @@ def get_stylesheet(mode: str = "dark") -> str:
         color: {c['text_dim']};
         font-size: 10px;
         font-weight: 700;
-        letter-spacing: -0.3px;
-        text-transform: uppercase;
     }}
     QLabel[class="status-dot-green"] {{
         color: {c['success']};
@@ -213,15 +225,11 @@ def get_stylesheet(mode: str = "dark") -> str:
         color: {c['success']};
         font-size: 10px;
         font-weight: 500;
-        letter-spacing: 0.5px;
-        text-transform: uppercase;
     }}
     QLabel[class="info-label"] {{
         color: {c['accent_text']};
         font-size: 10px;
         font-weight: 700;
-        letter-spacing: 0.5px;
-        text-transform: uppercase;
     }}
 
     /* === BUTTONS === */
@@ -351,19 +359,15 @@ def get_stylesheet(mode: str = "dark") -> str:
     QLineEdit:focus, QTextEdit:focus, QPlainTextEdit:focus {{
         border-color: {c['accent']};
     }}
-    QLineEdit::placeholder {{
-        color: {c['text_muted']};
-    }}
 
     /* Monospace caption editor */
     QTextEdit[class="caption-editor"] {{
-        background-color: rgba(24, 24, 27, 0.5);
+        background-color: {c['surface_translucent']};
         border: 1px solid {c['border']};
         border-radius: 8px;
         padding: 12px;
         font-family: 'Consolas', 'Courier New', monospace;
         font-size: 13px;
-        line-height: 1.6;
     }}
     QTextEdit[class="caption-editor"]:focus {{
         border-color: rgba(37, 99, 235, 0.5);
@@ -427,7 +431,7 @@ def get_stylesheet(mode: str = "dark") -> str:
     }}
     QCheckBox:hover {{
         color: {c['text_secondary']};
-        background-color: rgba(39, 39, 42, 0.5);
+        background-color: {c['hover_translucent']};
     }}
     QCheckBox::indicator {{
         width: 14px;
@@ -535,7 +539,6 @@ def get_stylesheet(mode: str = "dark") -> str:
         color: {c['text_dim']};
         font-size: 10px;
         font-weight: 700;
-        letter-spacing: 1px;
     }}
 
     /* === STATUS BAR === */
@@ -597,12 +600,12 @@ def get_stylesheet(mode: str = "dark") -> str:
         padding: 12px;
     }}
     QFrame[class="extra-options-container"] {{
-        background-color: rgba(24, 24, 27, 0.5);
+        background-color: {c['surface_translucent']};
         border: 1px solid {c['border']};
         border-radius: 6px;
     }}
     QFrame[class="gpu-pill"] {{
-        background-color: rgba(24, 24, 27, 0.5);
+        background-color: {c['surface_translucent']};
         border: 1px solid {c['border']};
         border-radius: 14px;
         padding: 4px 12px;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,11 @@
 name = "qwen3vl-captioner"
 version = "1.4.3"
 description = "Portable Qwen3-VL image captioning GUI with GGUF inference"
+# <3.13 because the pinned llama-cpp-python fork wheels are cp312-only
 requires-python = ">=3.11,<3.13"
 dependencies = [
+    # PyPI floor is for API compatibility only — GGUF Qwen3-VL captioning
+    # needs JamePeng's fork wheels, installed by setup.bat / setup.sh
     "llama-cpp-python>=0.3.0",
     "PyQt6>=6.7",
     "Pillow>=12.2.0",
@@ -24,3 +27,13 @@ qwen3vl-captioner = "app:main"
 [build-system]
 requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"
+
+# Explicit discovery: with app.py/doctor.py at the root next to two packages,
+# setuptools' flat-layout auto-detection refuses to build ("multiple top-level
+# packages"), which silently broke `pip install .` and the console script.
+[tool.setuptools]
+packages = ["engine", "gui"]
+py-modules = ["app", "doctor"]
+
+[tool.setuptools.package-data]
+gui = ["*.png"]

--- a/setup.bat
+++ b/setup.bat
@@ -22,7 +22,9 @@ echo [1/6] Checking for uv package manager...
 where uv >nul 2>&1
 if %ERRORLEVEL% NEQ 0 (
     echo      uv not found. Installing uv...
-    powershell -ExecutionPolicy Bypass -Command "irm https://astral.sh/uv/install.ps1 | iex"
+    REM Pinned installer version - a moving install.ps1 would execute whatever
+    REM the latest script happens to be at install time.
+    powershell -ExecutionPolicy Bypass -Command "irm https://astral.sh/uv/0.11.26/install.ps1 | iex"
     if %ERRORLEVEL% NEQ 0 (
         echo [ERROR] Failed to install uv. Please install manually from https://astral.sh/uv
         pause

--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,9 @@ echo "[1/5] Checking for uv package manager..."
 export PATH="$HOME/.local/bin:$PATH"
 if ! command -v uv >/dev/null 2>&1; then
     echo "      uv not found. Installing..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    # Pinned installer version — a moving `astral.sh/uv/install.sh` would
+    # execute whatever the latest script happens to be at install time.
+    curl -LsSf https://astral.sh/uv/0.11.26/install.sh | sh
     export PATH="$HOME/.local/bin:$PATH"
 fi
 echo "      uv ready."

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,3 +85,32 @@ def test_theme_and_token_convenience():
     cfg.save_config({"theme": "light", "hf_token": "hf_abc"})
     assert cfg.get_theme() == "light"
     assert cfg.get_hf_token() == "hf_abc"
+
+
+def test_save_config_reports_failure(monkeypatch, _isolated_config):
+    """A failed write must return False (the settings dialog surfaces it)
+    and must not clobber the previously saved file."""
+    assert cfg.save_config({"theme": "light"}) is True
+
+    def boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(cfg.os, "replace", boom)
+    assert cfg.save_config({"theme": "dark"}) is False
+    # The atomic write failed at the swap — the old content must survive.
+    assert cfg.load_config()["theme"] == "light"
+
+
+def test_save_config_returns_true_on_success():
+    assert cfg.save_config({"theme": "dark"}) is True
+
+
+def test_last_import_dir_round_trip():
+    assert cfg.get_last_import_dir() == ""
+    cfg.set_last_import_dir("/data/images")
+    assert cfg.get_last_import_dir() == "/data/images"
+
+
+def test_last_import_dir_rejects_non_string():
+    cfg.save_config({"last_import_dir": ["not", "a", "string"]})
+    assert cfg.get_last_import_dir() == ""

--- a/tests/test_download_part_identity.py
+++ b/tests/test_download_part_identity.py
@@ -1,0 +1,97 @@
+"""Tests for the .part identity-sidecar logic (gui.model_download_manager).
+
+The sidecar (.part.meta) records which repo/file/size a partial download
+belongs to, so a resume can never append onto a stale partial left under the
+same name by a *different* file — the silent-corruption case fixed in v1.4.3.
+These tests pin the sidecar unit contract: write/match, reject on mismatch,
+absent-sidecar detection (the grandfathering split), and the recorded-total
+fallback used by the HTTP 416 finalize path.
+
+ModelDownloadWorker is a plain QObject — no QApplication, threads, or network
+are needed to exercise these helpers.
+"""
+
+import json
+
+import pytest
+
+from gui.model_download_manager import ModelDownloadWorker
+
+
+@pytest.fixture
+def worker(tmp_path):
+    return ModelDownloadWorker(
+        repo_id="owner/repo",
+        filename="model.Q6_K.gguf",
+        target_dir=tmp_path,
+    )
+
+
+@pytest.fixture
+def part(tmp_path):
+    p = tmp_path / "model.Q6_K.gguf.part"
+    p.write_bytes(b"\x00" * 128)
+    return p
+
+
+def test_identity_round_trip(worker, part):
+    worker._write_part_identity(part, 1000)
+    assert worker._part_identity_matches(part, 1000) is True
+    assert worker._recorded_part_total(part) == 1000
+
+
+def test_mismatched_repo_is_rejected(worker, part, tmp_path):
+    other = ModelDownloadWorker(
+        repo_id="someone/else", filename="model.Q6_K.gguf", target_dir=tmp_path,
+    )
+    other._write_part_identity(part, 1000)
+    assert worker._part_identity_matches(part, 1000) is False
+    assert worker._recorded_part_total(part) == 0  # wrong owner — no fallback
+
+
+def test_mismatched_filename_is_rejected(worker, part, tmp_path):
+    other = ModelDownloadWorker(
+        repo_id="owner/repo", filename="different.Q2_K.gguf", target_dir=tmp_path,
+    )
+    other._write_part_identity(part, 1000)
+    assert worker._part_identity_matches(part, 1000) is False
+
+
+def test_mismatched_total_is_rejected(worker, part):
+    worker._write_part_identity(part, 1000)
+    # Remote file changed size since the partial was written — cannot resume.
+    assert worker._part_identity_matches(part, 2000) is False
+
+
+def test_absent_sidecar_does_not_match(worker, part):
+    """No sidecar => not a verified match (the resume path then applies the
+    pre-1.4.3 size-only grandfathering heuristic instead of discarding)."""
+    assert not worker._part_meta_path(part).exists()
+    assert worker._part_identity_matches(part, 1000) is False
+    assert worker._recorded_part_total(part) == 0
+
+
+def test_recorded_total_survives_probe_failure(worker, part):
+    """The 416 finalize path falls back to the recorded total when the live
+    size probe fails (probed_total == 0)."""
+    worker._write_part_identity(part, 4096)
+    assert worker._recorded_part_total(part) == 4096
+    # Sidecar with unknown total records 0 — no false finalize
+    worker._write_part_identity(part, 0)
+    assert worker._recorded_part_total(part) == 0
+
+
+def test_corrupt_sidecar_is_rejected(worker, part):
+    worker._part_meta_path(part).write_text("{not json", encoding="utf-8")
+    assert worker._part_identity_matches(part, 1000) is False
+    assert worker._recorded_part_total(part) == 0
+
+
+def test_sidecar_content_shape(worker, part):
+    worker._write_part_identity(part, 555)
+    data = json.loads(worker._part_meta_path(part).read_text(encoding="utf-8"))
+    assert data == {
+        "repo_id": "owner/repo",
+        "filename": "model.Q6_K.gguf",
+        "total": 555,
+    }

--- a/tests/test_download_part_identity.py
+++ b/tests/test_download_part_identity.py
@@ -15,7 +15,7 @@ import json
 
 import pytest
 
-from gui.model_download_manager import ModelDownloadWorker
+from gui.model_download_manager import ModelDownloadWorker, is_unsafe_repo_filename
 
 
 @pytest.fixture
@@ -95,3 +95,34 @@ def test_sidecar_content_shape(worker, part):
         "filename": "model.Q6_K.gguf",
         "total": 555,
     }
+
+
+@pytest.mark.parametrize(
+    "fname",
+    [
+        "/etc/passwd",             # POSIX absolute
+        "../outside.bin",          # POSIX traversal
+        "sub/../../outside.bin",   # nested POSIX traversal
+        "..\\evil.dll",            # Windows traversal (backslash separator)
+        "sub\\..\\..\\evil.dll",   # nested Windows traversal
+        "C:\\Windows\\evil.dll",   # Windows absolute with drive
+        "C:/Windows/evil.dll",     # drive with forward slashes
+        "C:evil.dll",              # drive-relative (no separator)
+        "\\\\server\\share\\x",    # UNC path
+    ],
+)
+def test_unsafe_repo_filenames_rejected(fname):
+    assert is_unsafe_repo_filename(fname) is True
+
+
+@pytest.mark.parametrize(
+    "fname",
+    [
+        "config.json",
+        "model-00001-of-00002.safetensors",
+        "sub/dir/tokenizer.json",
+        "weights..half.bin",       # '..' inside a NAME is fine
+    ],
+)
+def test_normal_repo_filenames_allowed(fname):
+    assert is_unsafe_repo_filename(fname) is False

--- a/tests/test_inference_image.py
+++ b/tests/test_inference_image.py
@@ -1,0 +1,66 @@
+"""Tests for the GGUF engine's image preprocessing (engine.inference).
+
+Covers the two silent-wrongness bugs found in the v1.4.3 QC audit:
+
+1. EXIF orientation — phone/camera JPEGs carrying Orientation 3/6/8 must be
+   transposed before encoding, or the model captions a sideways scene (the Qt
+   preview auto-rotates, so the user can't tell).
+2. Extreme aspect ratios — resizing must clamp both dimensions to >= 1 px so a
+   10000x2 strip can't crash resize with a zero dimension (which also aborted
+   the rest of a batch).
+
+These exercise ``image_to_data_uri`` only, which is pure PIL — no llama_cpp,
+no Qt, no network.
+"""
+
+import base64
+import io
+
+from PIL import Image
+
+from engine.inference import image_to_data_uri
+
+
+def _decode_data_uri(uri: str) -> Image.Image:
+    assert uri.startswith("data:image/png;base64,")
+    raw = base64.b64decode(uri.split(",", 1)[1])
+    return Image.open(io.BytesIO(raw))
+
+
+def test_exif_orientation_is_applied(tmp_path):
+    """A JPEG stored rotated with Orientation=6 must be transposed upright."""
+    path = tmp_path / "rotated.jpg"
+    img = Image.new("RGB", (100, 60), "red")
+    exif = Image.Exif()
+    exif[274] = 6  # Orientation tag: 90° CW rotation required for display
+    img.save(path, "JPEG", exif=exif.tobytes())
+
+    out = _decode_data_uri(image_to_data_uri(path))
+    # Transposing a 100x60 image by orientation 6 yields 60x100
+    assert out.size == (60, 100)
+
+
+def test_no_exif_image_unchanged(tmp_path):
+    path = tmp_path / "plain.png"
+    Image.new("RGB", (120, 80), "blue").save(path)
+
+    out = _decode_data_uri(image_to_data_uri(path))
+    assert out.size == (120, 80)
+
+
+def test_extreme_aspect_ratio_does_not_crash(tmp_path):
+    """A 5000x2 strip must downscale without a zero-height resize crash."""
+    path = tmp_path / "strip.png"
+    Image.new("RGB", (5000, 2), "green").save(path)
+
+    out = _decode_data_uri(image_to_data_uri(path, max_dim=1280))
+    assert out.size[0] == 1280
+    assert out.size[1] >= 1  # clamped, not zero
+
+
+def test_resize_keeps_aspect_for_normal_images(tmp_path):
+    path = tmp_path / "big.png"
+    Image.new("RGB", (2560, 1280), "white").save(path)
+
+    out = _decode_data_uri(image_to_data_uri(path, max_dim=1280))
+    assert out.size == (1280, 640)

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -6,6 +6,8 @@ encoder), backend routing (``gguf`` vs ``mlx``), the recommended default, and
 the parallel group/label structure that drives the dropdown headers.
 """
 
+import pytest
+
 from gui.model_download_manager import (
     MLX_MODEL_REGISTRY,
     MODEL_REGISTRY,
@@ -109,13 +111,25 @@ def test_display_names_are_known_registry_entries():
         assert name in known
 
 
-def test_mlx_backend_supported_matches_platform():
+@pytest.mark.parametrize(
+    "plat, machine, expected",
+    [
+        ("darwin", "arm64", True),    # Apple Silicon — the only supported combo
+        ("darwin", "x86_64", False),  # Intel Mac
+        ("win32", "AMD64", False),
+        ("linux", "x86_64", False),
+        ("win32", "arm64", False),    # arm64 alone isn't enough
+    ],
+)
+def test_mlx_backend_supported_truth_table(monkeypatch, plat, machine, expected):
+    """Pin concrete rows — re-deriving the production expression as the
+    test's own oracle could never catch a bug in it."""
     import platform
     import sys
 
-    assert mlx_backend_supported() == (
-        sys.platform == "darwin" and platform.machine() == "arm64"
-    )
+    monkeypatch.setattr(sys, "platform", plat)
+    monkeypatch.setattr(platform, "machine", lambda: machine)
+    assert mlx_backend_supported() is expected
 
 
 def test_model_file_exists(tmp_path):


### PR DESCRIPTION
## What this is

A fresh, deep QC audit of the entire v1.4.3 codebase — including an adversarial re-review of the just-merged health-check work (PR #19) — followed by fixes for everything confirmed. The audit produced **56 findings and all 56 survived independent adversarial verification** (several were *empirically reproduced* against live PyQt6 before being accepted). This PR fixes 47 of them (a few duplicates collapse into shared fixes); every cluster kept the CI mirror green.

**Test suite: 93 → 113 passing.** `pip-audit`: no known CVEs.

## The headline: a data-corruption race (HIGH, pre-existing)

A finished caption was cached and **auto-saved under whatever image was selected when it completed**, not the image it was generated for. Click thumbnail B while A's caption streams → A's caption silently overwrites `B.txt`. A click in the 100 ms between batch items likewise redirected the whole batch. Fixed at the root: results are pinned to the generating worker's own `image_path`, and batch items generate the popped queue entry regardless of selection.

## QC verdict on the previous batch (PR #19)

The v1.4.3 work held up, with 4 real flaws now fixed:
- The "uncancellable" encoder-download dialog **was dismissible with Esc** (verified empirically), dropping app modality while the nested event loop ran → now genuinely unclosable until done
- The new `.meta` sidecar check **discarded every pre-1.4.3 partial download** on upgrade → legacy partials grandfathered + stamped
- The HTTP 416 path dead-ended when the size probe failed → falls back to the sidecar's recorded size
- The streaming guard missed a `null` choices element → mirrored

## Everything else (by area)

**Engine** — EXIF orientation applied before inference (phone photos were captioned sideways, invisibly); zero-dimension resize clamp (extreme aspect ratios crashed the batch); CUDA 13.x DLL preload actually scans `bin\x64` (was a silent no-op); doctor stops reporting false "[OK] Wheel/CUDA match" on too-old toolkits, doesn't fail healthy Macs over optional MLX, and exits 2 on internal crashes (CI distinguishes).

**GUI** — saved theme applies at startup (always launched dark); light theme readable (hardcoded dark rgba → palette); invalid QSS removed; thumbnails decode at thumbnail size (no more UI stalls on big imports); batch state machine hardened (unload/re-entrancy/clear-all/stop-download races); RAM readout refreshes.

**Security** — `~/.vlcaptioner` 0700 + `config.json` 0600 (holds the HF token); token stripped on HTTPS→HTTP downgrade redirects; update-check output HTML-escaped; snapshot downloads reject path traversal; CI workflows get least-privilege `permissions`; `uv` bootstrap pinned.

**UX** — download **speed + ETA**; batch time-remaining; **keyboard shortcuts** (Ctrl+S / Ctrl+G / Ctrl+←→ / PgUp+PgDn); **drag & drop anywhere**; "model not downloaded" offers the download; friendlier error dialogs (traceback in expandable details); last-used import folder remembered; stem-collision warning; maximize button wired.

**Packaging/CI** — `pip install .` was entirely broken (setuptools flat-layout) → fixed; Windows smoke parses the wheel URL from `setup.bat` (single source); new CI job HEAD-checks all 5 pinned wheel URLs so a deleted release fails CI, not user installs; `requirements-dev.txt` actually consumed by CI; tautological platform test replaced with a real truth table.

## Test plan

- ✅ `compileall` / `pyflakes` clean
- ✅ `pytest tests/ -q` → **113 passed** (20 new: EXIF/aspect prep, sidecar contract, config failure surfacing, platform truth table)
- ✅ Both workflow YAMLs parse
- ✅ `pip-audit` clean
- ⚠️ GUI threading changes validated at import level by CI (sandbox lacks libEGL); the misattribution fix, modal-dialog subclass, and batch-pinning logic are the parts most worth human eyes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gKBrKPmcYgQKp9oi1b2di

---
_Generated by [Claude Code](https://claude.ai/code/session_019gKBrKPmcYgQKp9oi1b2di)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added download speed and ETA progress updates, drag-and-drop folder support, keyboard shortcuts, and improved model/download prompts.
  * Added a “last imported folder” setting and restored it across file dialogs.

* **Bug Fixes**
  * Fixed image rotation handling, safer resizing, and better caption consistency during selection changes and batch runs.
  * Improved download resume, cancel behavior, CUDA compatibility checks, and update-message safety.
  * Restored theme preference on startup and tightened file handling for saved settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->