### PR TITLE
Release engineering: version-sync CI guard + tag-verified auto-release (v1.4.3 prep)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+# Pushing a version tag (e.g. V1.4.3) publishes the GitHub release — but
+# only after proving the tag matches every in-repo statement of the
+# version (gui/version.py, pyproject.toml, README title + badge, newest
+# CHANGELOG entry). The v1.4.2 release shipped with the in-app version
+# still reading 1.4.1; this gate makes that class of mismatch impossible
+# to release again. Release notes are extracted from CHANGELOG.md.
+
+on:
+  push:
+    tags: ["V*.*.*", "v*.*.*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify tag matches every in-repo version
+        run: |
+          python3 - "$GITHUB_REF_NAME" <<'EOF'
+          import re, sys, tomllib
+
+          tag = sys.argv[1].lstrip("Vv")
+          app = re.search(
+              r'APP_VERSION\s*=\s*"([^"]+)"', open("gui/version.py").read()
+          ).group(1)
+          proj = tomllib.load(open("pyproject.toml", "rb"))["project"]["version"]
+          readme = open("README.md").read()
+          badge = re.search(
+              r"img\.shields\.io/badge/version-([\d.]+)-", readme
+          ).group(1)
+          newest = re.search(
+              r"^## \[([\d.]+)\]", open("CHANGELOG.md").read(), re.M
+          ).group(1)
+
+          rows = {
+              "git tag": tag,
+              "gui/version.py": app,
+              "pyproject.toml": proj,
+              "README badge": badge,
+              "CHANGELOG newest": newest,
+          }
+          for name, value in rows.items():
+              print(f"  {name:18} {value}")
+          title_ok = f"V{tag}" in readme
+          print(f"  {'README title':18} {'contains V' + tag if title_ok else 'MISSING V' + tag}")
+
+          if len(set(rows.values())) != 1 or not title_ok:
+              sys.exit(
+                  "::error::Version mismatch — refusing to publish. "
+                  "Sync every location above to the tag, re-tag, and push again."
+              )
+          print("All version statements agree — publishing.")
+          EOF
+
+      - name: Extract this version's CHANGELOG section as release notes
+        run: |
+          python3 - <<'EOF'
+          import re
+
+          text = open("CHANGELOG.md").read()
+          m = re.search(r"^## \[[\d.]+\][^\n]*\n(.*?)(?=^## \[|\Z)", text, re.M | re.S)
+          notes = m.group(1).strip() + "\n"
+          open("RELEASE_NOTES.md", "w").write(notes)
+          print(notes)
+          EOF
+
+      - name: Publish the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "Qwen3-VL Captioner $GITHUB_REF_NAME" \
+            --notes-file RELEASE_NOTES.md \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,14 +48,20 @@ jobs:
           }
           for name, value in rows.items():
               print(f"  {name:18} {value}")
-          title_ok = f"V{tag}" in readme
-          print(f"  {'README title':18} {'contains V' + tag if title_ok else 'MISSING V' + tag}")
+          # Check the <h1> specifically — "V<tag>" appears in What's New
+          # headings too, which would mask a stale title.
+          title = re.search(r"<h1[^>]*>([^<]*)</h1>", readme)
+          title_ok = bool(title) and f"V{tag}" in title.group(1)
+          print(f"  {'README <h1> title':18} {title.group(1).strip() if title else 'NOT FOUND'}")
 
           if len(set(rows.values())) != 1 or not title_ok:
-              sys.exit(
+              # Workflow commands are parsed from stdout; a sys.exit message
+              # goes to stderr and the annotation would be lost.
+              print(
                   "::error::Version mismatch — refusing to publish. "
                   "Sync every location above to the tag, re-tag, and push again."
               )
+              sys.exit(1)
           print("All version statements agree — publishing.")
           EOF
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,44 @@ All notable changes to this project are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/); versions correspond to
 git tags (`V1.x.x`).
 
-## [1.4.3] — Unreleased
+## [1.4.3] — 2026-07-30
 
 Maintenance release from a full repository health check, followed by a second
 deep QC audit of the entire codebase (56 findings, each adversarially
 verified against the source — several reproduced empirically against live
-PyQt6 before fixing).
+PyQt6 before fixing), plus a rework of the Windows install diagnostics
+driven by a live support case (issue #22).
+
+### Fixed (install diagnostics — issue #22)
+- **False "CPU build detected" warning on healthy CUDA installs.** The
+  v0.3.40 wheels carry the `+cuNNN` CUDA tag only in the wheel filename —
+  the installed metadata reports plain `0.3.40` — so `doctor.py` warned
+  "CPU build" on every correct GPU install and the wheel/toolkit match
+  check silently disabled itself. CUDA builds are now detected by the
+  `ggml-cuda.dll` they ship, and the `+cuNNN` tag is recovered from the
+  PEP 610 `direct_url.json` that pip/uv record, restoring the match check.
+- **`WinError 127` engine-load failures are now diagnosed, not shrugged
+  at.** `diagnose.bat` scans the DLL search locations that outrank the
+  app's own folders (python dir, System32, Windows dir, CWD) plus PATH,
+  and prints every conflicting llama.cpp-family DLL ranked by whether it
+  can actually shadow the wheel's copy. Remediation always leads with the
+  MSVC-runtime update and warns against deleting System32 files (rename
+  reversibly instead). Confirmed live on issue #22: a stale
+  `libomp140.x86_64.dll` in System32.
+- `llama_cpp/bin` (new in the v0.3.40 wheel layout) is registered on the
+  DLL search path alongside `lib`, and all diagnostic stat/scan calls
+  degrade gracefully on unreadable directories instead of crashing app
+  startup or the doctor.
+
+### Added (release process)
+- **Version-sync guard test**: `gui/version.py`, `pyproject.toml`, the
+  README title/badge, and the newest CHANGELOG entry must all agree on the
+  version — any drift fails CI on every PR.
+- **Tag-verified automatic releases**: pushing a `V*` tag now runs a
+  workflow that verifies the tag matches every in-repo version and only
+  then creates the GitHub release with notes extracted from this file —
+  a tag/file mismatch (the v1.4.2 ZIP shipped showing "1.4.1" in-app)
+  can no longer become a release.
 
 ### Fixed (QC audit round 2)
 - **Caption/save misattribution race (data corruption).** A finished caption

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ No new models — two full audit passes over the codebase (85 verified findings 
 - **No more phantom "update available" popup**, no more window freeze during vision-encoder downloads, and your saved **light/dark theme actually applies at startup**.
 - **Downloads got smarter**: live **speed + ETA**, free-disk-space pre-flight, corruption-proof resume (including partials from older versions), and your HF token is stored `0600` and never sent over plain HTTP.
 - **Faster & smoother**: thumbnails decode at thumbnail size (no more UI stalls on big imports), **keyboard shortcuts** (Ctrl+S save, Ctrl+G generate, Ctrl+←/→ navigate), **drag & drop anywhere**, batch ETA, and a download offer right in the "model not downloaded" dialog.
-- Test suite grew to **113 tests**; CI now HEAD-checks the pinned wheel URLs so a deleted release breaks CI, not your install.
+- **The install doctor got real diagnostic teeth.** The false "CPU build detected" warning on healthy GPU installs is gone, and `diagnose.bat` now pinpoints the exact conflicting DLL (System32, PATH, another AI app) behind `WinError 127` startup failures — with safe, reversible fix steps.
+- Test suite grew to **139 tests**; CI now HEAD-checks the pinned wheel URLs so a deleted release breaks CI (not your install), and every release tag is verified against the in-app version before it publishes.
 
 See [CHANGELOG.md](CHANGELOG.md) for the complete list.
 

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,0 +1,62 @@
+"""Version-sync guard — the "revision block" of this repository.
+
+Every user-visible statement of the app version must agree:
+gui/version.py (the single source of truth), pyproject.toml, the README
+title and badge, and the newest CHANGELOG entry. The v1.4.2 release
+shipped with the in-app version still reading 1.4.1 (issue #22 follow-up)
+because nothing enforced this; now any drift fails CI on every PR.
+
+The tag-to-version check (the other half of that failure) lives in
+.github/workflows/release.yml, which refuses to publish a release whose
+tag does not match APP_VERSION.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def app_version() -> str:
+    text = (REPO / "gui" / "version.py").read_text(encoding="utf-8")
+    m = re.search(r'APP_VERSION\s*=\s*"([^"]+)"', text)
+    assert m, "APP_VERSION not found in gui/version.py"
+    return m.group(1)
+
+
+def test_app_version_is_semver():
+    assert re.fullmatch(r"\d+\.\d+\.\d+", app_version())
+
+
+def test_pyproject_matches_app_version():
+    with open(REPO / "pyproject.toml", "rb") as f:
+        pyproject = tomllib.load(f)
+    assert pyproject["project"]["version"] == app_version()
+
+
+def test_readme_title_and_badge_match_app_version():
+    version = app_version()
+    readme = (REPO / "README.md").read_text(encoding="utf-8")
+
+    title = re.search(r"<h1[^>]*>([^<]*)</h1>", readme)
+    assert title, "README <h1> title not found"
+    assert f"V{version}" in title.group(1), (
+        f"README title says {title.group(1)!r} but APP_VERSION is {version}"
+    )
+
+    badge = re.search(r"img\.shields\.io/badge/version-([\d.]+)-", readme)
+    assert badge, "README version badge not found"
+    assert badge.group(1) == version, (
+        f"README badge says {badge.group(1)} but APP_VERSION is {version}"
+    )
+
+
+def test_newest_changelog_entry_matches_app_version():
+    changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
+    entry = re.search(r"^## \[([\d.]+)\]", changelog, re.MULTILINE)
+    assert entry, "no version heading found in CHANGELOG.md"
+    assert entry.group(1) == app_version(), (
+        f"newest CHANGELOG entry is {entry.group(1)} but APP_VERSION is "
+        f"{app_version()} — add a CHANGELOG section for the new version"
+    )

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -20,7 +20,7 @@ REPO = Path(__file__).resolve().parent.parent
 
 def app_version() -> str:
     text = (REPO / "gui" / "version.py").read_text(encoding="utf-8")
-    m = re.search(r'APP_VERSION\s*=\s*"([^"]+)"', text)
+    m = re.search(r"""APP_VERSION\s*=\s*['"]([^'"]+)['"]""", text)
     assert m, "APP_VERSION not found in gui/version.py"
     return m.group(1)
 


### PR DESCRIPTION
## Summary

Follow-up to #22/#23: the v1.4.2 release ZIP shipped with the in-app version still reading **1.4.1** — the tag and the files disagreed, and nothing checked. This PR finalizes the 1.4.3 release docs and adds two mechanical guards so version drift can never ship again (treating the version like the revision block on an engineering drawing — checked at every gate, not by eye):

## Changes

**Guards**
- `tests/test_version_sync.py` — `gui/version.py` (single source of truth), `pyproject.toml`, the README title + badge, and the newest CHANGELOG entry must all agree on the version. Runs in the existing CI test job on **every PR**, so drift is caught at review time.
- `.github/workflows/release.yml` — pushing a `V*.*.*` tag now: (1) verifies the tag against every in-repo version statement, failing loudly on any mismatch; (2) extracts that version's CHANGELOG section; (3) publishes the GitHub release automatically. A tag/file mismatch like v1.4.2's can no longer become a release, and cutting a release is now just pushing a verified tag.

**Release docs (1.4.3)**
- `CHANGELOG.md` — 1.4.3 entry dated for release and extended with the issue #22 install-diagnostics work (#23) and the new release process.
- `README.md` — What's New in V1.4.3 gains the diagnostics bullet; test count updated to the current 139.

## Verification

- Full suite: **143 passed** (139 existing + 4 new version-sync guards), run headlessly with PyQt6 installed.
- `pyflakes` clean; workflow YAML validated.
- The new sync test passes against the current tree, and would have failed on the v1.4.2 tree (files said 1.4.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWxaNyK2MKek6Nz8qVTv5D

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWxaNyK2MKek6Nz8qVTv5D)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/tests, a release workflow, and documentation; no runtime application or security-sensitive code paths are modified.
> 
> **Overview**
> **Release engineering for v1.4.3** — prevents another v1.4.2-style mismatch where the tag and in-app version disagreed.
> 
> **`tests/test_version_sync.py`** enforces that `gui/version.py`, `pyproject.toml`, the README `<h1>`/version badge, and the top **CHANGELOG** heading all match on every PR.
> 
> **`.github/workflows/release.yml`** runs on `V*`/`v*` tag pushes: it refuses to publish unless the tag matches those same sources (including README title), extracts the newest CHANGELOG section into release notes, then creates the GitHub release with `gh`.
> 
> **Docs:** **CHANGELOG** 1.4.3 is dated and documents install-diagnostics (#22) and this release process; **README** “What’s New” adds the doctor/diagnostics bullet, bumps the cited test count to **139**, and notes tag verification before publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bf8eab5c78535235df459f6d5583b790acd5527. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->