### PR TITLE
Add manual dispatch to the release workflow (one-click releases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,15 +26,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Resolve tag name
+      - name: Resolve and validate the tag name
         env:
-          TAG_INPUT: ${{ inputs.tag }}
+          # github.event.inputs is safe to reference on every event type;
+          # the bare `inputs` context is not defined for tag-push runs.
+          TAG_INPUT: ${{ github.event.inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "TAG_NAME=$TAG_INPUT" >> "$GITHUB_ENV"
+            TAG="$TAG_INPUT"
           else
-            echo "TAG_NAME=$GITHUB_REF_NAME" >> "$GITHUB_ENV"
+            TAG="$GITHUB_REF_NAME"
           fi
+          # Strict shape check before the value goes anywhere (GITHUB_ENV,
+          # git, gh): rejects option-like names, newlines, and junk tags.
+          if [[ ! "$TAG" =~ ^[Vv][0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::'$TAG' is not a V<major>.<minor>.<patch> version tag"
+            exit 1
+          fi
+          echo "TAG_NAME=$TAG" >> "$GITHUB_ENV"
 
       - name: Verify tag matches every in-repo version
         run: |
@@ -97,8 +106,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "$TAG_NAME"
-          git push origin "$TAG_NAME"
+          git tag -- "$TAG_NAME"
+          git push origin "refs/tags/$TAG_NAME"
 
       - name: Publish the GitHub release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ name: Release
 on:
   push:
     tags: ["V*.*.*", "v*.*.*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to create and publish (e.g. V1.4.3) — must match the in-repo version"
+        required: true
 
 permissions:
   contents: write
@@ -21,9 +26,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve tag name
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "TAG_NAME=$TAG_INPUT" >> "$GITHUB_ENV"
+          else
+            echo "TAG_NAME=$GITHUB_REF_NAME" >> "$GITHUB_ENV"
+          fi
+
       - name: Verify tag matches every in-repo version
         run: |
-          python3 - "$GITHUB_REF_NAME" <<'EOF'
+          python3 - "$TAG_NAME" <<'EOF'
           import re, sys, tomllib
 
           tag = sys.argv[1].lstrip("Vv")
@@ -77,11 +92,19 @@ jobs:
           print(notes)
           EOF
 
+      - name: Create and push the tag (manual dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+
       - name: Publish the GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "Qwen3-VL Captioner $GITHUB_REF_NAME" \
+          gh release create "$TAG_NAME" \
+            --title "Qwen3-VL Captioner $TAG_NAME" \
             --notes-file RELEASE_NOTES.md \
             --verify-tag


### PR DESCRIPTION
## Summary

Small follow-up to #24: the release workflow gains a `workflow_dispatch` trigger with a `tag` input, so a release can be cut from the Actions tab with one click. The dispatch path runs the identical version-verification gate, then creates and pushes the tag itself using the Actions token, and publishes the release. The existing tag-push trigger is unchanged.

Motivation: some environments (including the remote session that maintains this repo) hold branch-scoped git credentials that cannot push tags. This also gives maintainers a "release button" — no local git required.

## Changes

- `.github/workflows/release.yml`: `workflow_dispatch` with required `tag` input (passed via `env` to avoid shell interpolation of the raw input); a resolve step sets `TAG_NAME` from either the dispatch input or `GITHUB_REF_NAME`; a dispatch-only step creates and pushes the tag after verification passes; publish uses `$TAG_NAME` throughout. Tag pushes from `GITHUB_TOKEN` do not re-trigger the workflow, so no double-run.

## Verification

- YAML validated; version-sync tests pass (4/4).
- The verification gate is untouched — a dispatched tag that doesn't match every in-repo version statement still refuses to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWxaNyK2MKek6Nz8qVTv5D

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWxaNyK2MKek6Nz8qVTv5D)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to release automation; existing tag-push releases behave the same, and the in-repo version gate still blocks mismatched tags before publish.
> 
> **Overview**
> Adds a **manual “Run workflow”** path to the release workflow so maintainers can publish from the Actions tab without pushing a tag locally.
> 
> The workflow now accepts **`workflow_dispatch`** with a required **`tag`** input. A **Resolve tag name** step sets `TAG_NAME` from that input on dispatch, or from `GITHUB_REF_NAME` on tag push (unchanged trigger). Version verification and CHANGELOG extraction still run against `TAG_NAME`; the verification gate itself is not modified.
> 
> On dispatch only, after verification passes, a new step **creates and pushes the tag** with the Actions bot identity. **`gh release create`** then uses `$TAG_NAME` for title and publish instead of `$GITHUB_REF_NAME`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c656ee2ed7f5dd5a896d51ba4076d6f182b3918. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->